### PR TITLE
S3 client should use instance profile if no credentials provided.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.10.16</version>
+            <version>1.11.119</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/jenkins/plugins/itemstorage/s3/ClientHelper.java
+++ b/src/main/java/jenkins/plugins/itemstorage/s3/ClientHelper.java
@@ -2,12 +2,14 @@ package jenkins.plugins.itemstorage.s3;
 
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.regions.Region;
 import com.amazonaws.regions.RegionUtils;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import hudson.ProxyConfiguration;
 
 import java.io.Serializable;
@@ -51,13 +53,16 @@ public class ClientHelper implements Serializable {
         if (client == null) {
 
             if (getCredentials() == null) {
-                client = new AmazonS3Client(getClientConfiguration(proxy));
+                client = AmazonS3ClientBuilder.standard()
+                            .withRegion(region)
+                            .withClientConfiguration(getClientConfiguration(proxy))
+                            .build();
             } else {
-                client = new AmazonS3Client(getCredentials(), getClientConfiguration(proxy));
-            }
-
-            if (region != null) {
-                client.setRegion(getRegionFromString(region));
+                client = AmazonS3ClientBuilder.standard()
+                            .withRegion(region)
+                            .withCredentials(new AWSStaticCredentialsProvider(getCredentials()))
+                            .withClientConfiguration(getClientConfiguration(proxy))
+                            .build();
             }
         }
 


### PR DESCRIPTION
The S3 client should use the S3 credentials provider to loop over
the known as authentication systems to get credentials:

 - Environment variables
 - ~/.aws/credentials
 - instance profile

etc.

The default client provided by the [AmazonS3ClientBuilder](https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3ClientBuilder.java#L46) uses [S3CredentialsProviderChain.java](https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/S3CredentialsProviderChain.java) looks in [DefaultAWSCredentialsProviderChain.java](https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-core/src/main/java/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.java) and then falls back to null if none found. 

Signed-off-by: Ian Duffy <ian.duffy@zalando.ie>