### PR TITLE
Adds support for non AWS S3 endpoints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.10.16</version>
+            <version>1.11.119</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/jenkins/plugins/itemstorage/s3/ClientHelper.java
+++ b/src/main/java/jenkins/plugins/itemstorage/s3/ClientHelper.java
@@ -3,11 +3,14 @@ package jenkins.plugins.itemstorage.s3;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.regions.Region;
 import com.amazonaws.regions.RegionUtils;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import hudson.ProxyConfiguration;
 
 import java.io.Serializable;
@@ -25,6 +28,9 @@ public class ClientHelper implements Serializable {
     private final String secretKey;
     private final String region;
     private final ProxyConfiguration proxy;
+    private final String endpoint;
+    private final String signerVersion;
+    private final Boolean pathStyleAccess;
 
     private transient AWSCredentials credentials;
     private transient AmazonS3 client;
@@ -34,8 +40,15 @@ public class ClientHelper implements Serializable {
     }
 
     public ClientHelper(AWSCredentials credentials, String region, ProxyConfiguration proxy) {
+        this(credentials, null, region, proxy, null, false);
+    }
+
+    public ClientHelper(AWSCredentials credentials, String endpoint, String region, ProxyConfiguration proxy, String signerVersion, Boolean pathStyleAccess) {
         this.region = region;
         this.proxy = proxy;
+        this.endpoint = endpoint;
+        this.signerVersion = signerVersion;
+        this.pathStyleAccess = pathStyleAccess;
 
         if (credentials != null) {
             this.accessKey = credentials.getAWSAccessKeyId();
@@ -46,19 +59,27 @@ public class ClientHelper implements Serializable {
         }
     }
 
-    public synchronized AmazonS3 client()
-    {
+    public synchronized AmazonS3 client() {
         if (client == null) {
+            AmazonS3ClientBuilder builder = AmazonS3ClientBuilder.standard();
+            ClientConfiguration config = getClientConfiguration(proxy);
 
-            if (getCredentials() == null) {
-                client = new AmazonS3Client(getClientConfiguration(proxy));
-            } else {
-                client = new AmazonS3Client(getCredentials(), getClientConfiguration(proxy));
+            if (getCredentials() != null) {
+                builder.setCredentials(new AWSStaticCredentialsProvider(getCredentials()));
+            }
+
+            if (endpoint != null) {
+                builder.setEndpointConfiguration(new EndpointConfiguration(endpoint, region));
+                builder.setPathStyleAccessEnabled(pathStyleAccess);
+                config.setSignerOverride(signerVersion);
             }
 
             if (region != null) {
-                client.setRegion(getRegionFromString(region));
+                builder.setRegion(region);
             }
+
+            builder.setClientConfiguration(config);
+            client = builder.build();
         }
 
         return client;

--- a/src/main/java/jenkins/plugins/itemstorage/s3/S3Profile.java
+++ b/src/main/java/jenkins/plugins/itemstorage/s3/S3Profile.java
@@ -52,8 +52,8 @@ public class S3Profile {
     private final long retryTime;
 
     @DataBoundConstructor
-    public S3Profile(AmazonWebServicesCredentials credentials, Integer maxRetries, Long retryTime) {
-        this.helper = new ClientHelper(credentials != null ? credentials.getCredentials() : null, getProxy());
+    public S3Profile(AmazonWebServicesCredentials credentials, String endpoint, String signerVersion, Boolean pathStyleAccess, Integer maxRetries, Long retryTime) {
+        this.helper = new ClientHelper(credentials != null ? credentials.getCredentials() : null, endpoint, null, getProxy(), signerVersion, pathStyleAccess);
         this.maxRetries = maxRetries != null ? maxRetries : 5;
         this.retryTime = retryTime != null ? retryTime : 5L;
     }

--- a/src/main/resources/jenkins/plugins/itemstorage/Messages.properties
+++ b/src/main/resources/jenkins/plugins/itemstorage/Messages.properties
@@ -1,2 +1,3 @@
 LocalItemStorage.DisplayName = Built-in Jenkins storage
 S3ItemStorage.DisplayName = Amazon S3 storage
+NonAWSS3ItemStorage.DisplayName = S3 API compatible storage

--- a/src/main/resources/jenkins/plugins/itemstorage/s3/NonAWSS3ItemStorage/config.jelly
+++ b/src/main/resources/jenkins/plugins/itemstorage/s3/NonAWSS3ItemStorage/config.jelly
@@ -1,0 +1,52 @@
+<!--
+ * The MIT License
+ *
+ * Copyright 2016 Peter Hayes.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+-->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
+         xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
+         xmlns:p="/lib/hudson/project">
+
+    <f:entry title="${%Credentials}" field="credentialsId">
+        <f:select />
+    </f:entry>
+
+    <f:entry title="${%S3 Bucket Name}" field="bucketName">
+        <f:textbox />
+    </f:entry>
+
+    <f:entry title="${%S3 Endpoint}" field="endpoint">
+        <f:textbox />
+    </f:entry>
+
+    <f:entry title="${%Region}" field="region">
+        <f:textbox />
+    </f:entry>
+
+    <f:entry title="${%Signer Version}" field="signerVersion">
+        <f:select />
+    </f:entry>
+
+    <f:entry title="${%Path Style Access}" field="pathStyleAccess">
+        <f:checkbox />
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/jenkins/plugins/itemstorage/s3/NonAWSS3ItemStorage/help-bucketName.html
+++ b/src/main/resources/jenkins/plugins/itemstorage/s3/NonAWSS3ItemStorage/help-bucketName.html
@@ -1,0 +1,27 @@
+<!--
+  - The MIT License
+  -
+  - Copyright (c) 2011, Manufacture Francaise des Pneumatiques Michelin, Romain Seguy
+  -
+  - Permission is hereby granted, free of charge, to any person obtaining a copy
+  - of this software and associated documentation files (the "Software"), to deal
+  - in the Software without restriction, including without limitation the rights
+  - to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  - copies of the Software, and to permit persons to whom the Software is
+  - furnished to do so, subject to the following conditions:
+  -
+  - The above copyright notice and this permission notice shall be included in
+  - all copies or substantial portions of the Software.
+  -
+  - THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  - IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  - FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  - AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  - LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  - OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  - THE SOFTWARE.
+  -->
+
+<div>
+    The S3 bucket that will be used to store the data associated with items that utilize this storage capability.
+</div>

--- a/src/main/resources/jenkins/plugins/itemstorage/s3/NonAWSS3ItemStorage/help-credentialsId.html
+++ b/src/main/resources/jenkins/plugins/itemstorage/s3/NonAWSS3ItemStorage/help-credentialsId.html
@@ -1,0 +1,27 @@
+<!--
+  - The MIT License
+  -
+  - Copyright (c) 2011, Manufacture Francaise des Pneumatiques Michelin, Romain Seguy
+  -
+  - Permission is hereby granted, free of charge, to any person obtaining a copy
+  - of this software and associated documentation files (the "Software"), to deal
+  - in the Software without restriction, including without limitation the rights
+  - to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  - copies of the Software, and to permit persons to whom the Software is
+  - furnished to do so, subject to the following conditions:
+  -
+  - The above copyright notice and this permission notice shall be included in
+  - all copies or substantial portions of the Software.
+  -
+  - THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  - IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  - FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  - AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  - LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  - OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  - THE SOFTWARE.
+  -->
+
+<div>
+    Select the AWS style credentials that should be used to authenticate.
+</div>

--- a/src/main/resources/jenkins/plugins/itemstorage/s3/NonAWSS3ItemStorage/help-endpoint.html
+++ b/src/main/resources/jenkins/plugins/itemstorage/s3/NonAWSS3ItemStorage/help-endpoint.html
@@ -1,0 +1,27 @@
+<!--
+  - The MIT License
+  -
+  - Copyright (c) 2011, Manufacture Francaise des Pneumatiques Michelin, Romain Seguy
+  -
+  - Permission is hereby granted, free of charge, to any person obtaining a copy
+  - of this software and associated documentation files (the "Software"), to deal
+  - in the Software without restriction, including without limitation the rights
+  - to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  - copies of the Software, and to permit persons to whom the Software is
+  - furnished to do so, subject to the following conditions:
+  -
+  - The above copyright notice and this permission notice shall be included in
+  - all copies or substantial portions of the Software.
+  -
+  - THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  - IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  - FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  - AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  - LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  - OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  - THE SOFTWARE.
+  -->
+
+<div>
+    The endpoint for the S3 service.
+</div>

--- a/src/main/resources/jenkins/plugins/itemstorage/s3/NonAWSS3ItemStorage/help-pathStyleAccess.html
+++ b/src/main/resources/jenkins/plugins/itemstorage/s3/NonAWSS3ItemStorage/help-pathStyleAccess.html
@@ -1,0 +1,27 @@
+<!--
+  - The MIT License
+  -
+  - Copyright (c) 2011, Manufacture Francaise des Pneumatiques Michelin, Romain Seguy
+  -
+  - Permission is hereby granted, free of charge, to any person obtaining a copy
+  - of this software and associated documentation files (the "Software"), to deal
+  - in the Software without restriction, including without limitation the rights
+  - to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  - copies of the Software, and to permit persons to whom the Software is
+  - furnished to do so, subject to the following conditions:
+  -
+  - The above copyright notice and this permission notice shall be included in
+  - all copies or substantial portions of the Software.
+  -
+  - THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  - IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  - FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  - AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  - LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  - OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  - THE SOFTWARE.
+  -->
+
+<div>
+    If true uses path style urls for accessing buckets instead of virtual host style urls where the bucket name is part of the domain name.
+</div>

--- a/src/main/resources/jenkins/plugins/itemstorage/s3/NonAWSS3ItemStorage/help-region.html
+++ b/src/main/resources/jenkins/plugins/itemstorage/s3/NonAWSS3ItemStorage/help-region.html
@@ -1,0 +1,27 @@
+<!--
+  - The MIT License
+  -
+  - Copyright (c) 2011, Manufacture Francaise des Pneumatiques Michelin, Romain Seguy
+  -
+  - Permission is hereby granted, free of charge, to any person obtaining a copy
+  - of this software and associated documentation files (the "Software"), to deal
+  - in the Software without restriction, including without limitation the rights
+  - to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  - copies of the Software, and to permit persons to whom the Software is
+  - furnished to do so, subject to the following conditions:
+  -
+  - The above copyright notice and this permission notice shall be included in
+  - all copies or substantial portions of the Software.
+  -
+  - THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  - IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  - FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  - AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  - LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  - OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  - THE SOFTWARE.
+  -->
+
+<div>
+    The region that this bucket is located in.
+</div>

--- a/src/main/resources/jenkins/plugins/itemstorage/s3/NonAWSS3ItemStorage/help-signerVersion.html
+++ b/src/main/resources/jenkins/plugins/itemstorage/s3/NonAWSS3ItemStorage/help-signerVersion.html
@@ -1,0 +1,27 @@
+<!--
+  - The MIT License
+  -
+  - Copyright (c) 2011, Manufacture Francaise des Pneumatiques Michelin, Romain Seguy
+  -
+  - Permission is hereby granted, free of charge, to any person obtaining a copy
+  - of this software and associated documentation files (the "Software"), to deal
+  - in the Software without restriction, including without limitation the rights
+  - to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  - copies of the Software, and to permit persons to whom the Software is
+  - furnished to do so, subject to the following conditions:
+  -
+  - The above copyright notice and this permission notice shall be included in
+  - all copies or substantial portions of the Software.
+  -
+  - THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  - IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  - FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  - AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  - LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  - OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  - THE SOFTWARE.
+  -->
+
+<div>
+    The signer to use for signing requests to S3.
+</div>

--- a/src/main/resources/jenkins/plugins/itemstorage/s3/NonAWSS3ItemStorage/help.html
+++ b/src/main/resources/jenkins/plugins/itemstorage/s3/NonAWSS3ItemStorage/help.html
@@ -1,0 +1,27 @@
+<!--
+  - The MIT License
+  -
+  - Copyright (c) 2011, Manufacture Francaise des Pneumatiques Michelin, Romain Seguy
+  -
+  - Permission is hereby granted, free of charge, to any person obtaining a copy
+  - of this software and associated documentation files (the "Software"), to deal
+  - in the Software without restriction, including without limitation the rights
+  - to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  - copies of the Software, and to permit persons to whom the Software is
+  - furnished to do so, subject to the following conditions:
+  -
+  - The above copyright notice and this permission notice shall be included in
+  - all copies or substantial portions of the Software.
+  -
+  - THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  - IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  - FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  - AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  - LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  - OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  - THE SOFTWARE.
+  -->
+
+<div>
+    Backs item storage with a S3 API compatible endpoint.
+</div>


### PR DESCRIPTION
This PR adds the option to configure another item storage that uses the S3 API to store the cache but can be pointed at non AWS S3 compatible endpoints such as Ceph or Swift.

It uses the same code as AWS S3 item storage but exposes a few extra configuration options.