### PR TITLE
Fix using multiple caches while using the S3 storage

### DIFF
--- a/src/main/java/jenkins/plugins/itemstorage/s3/S3Callable.java
+++ b/src/main/java/jenkins/plugins/itemstorage/s3/S3Callable.java
@@ -59,7 +59,7 @@ abstract class S3Callable<T> extends MasterToSlaveFileCallable<T> {
         try {
             return invoke(transferManager, f, channel);
         } finally {
-            transferManager.shutdownNow();
+            transferManager.shutdownNow(false);
         }
     }
 

--- a/src/main/java/jenkins/plugins/jobcacher/ArbitraryFileCache.java
+++ b/src/main/java/jenkins/plugins/jobcacher/ArbitraryFileCache.java
@@ -185,7 +185,7 @@ public class ArbitraryFileCache extends Cache {
             return null;
         }
 
-        if (hasCacheValidityDecidingFile(workspace) && isCacheOutdated(cachesRoot, workspace)) {
+        if (isCacheValidityDecidingFileConfigured() && isCacheOutdated(cachesRoot, workspace)) {
             return null;
         }
 
@@ -209,8 +209,8 @@ public class ArbitraryFileCache extends Cache {
         return !matchesCurrentCacheValidityDecidingFileHash(previousClearCacheTriggerFileHash, workspace);
     }
 
-    private boolean hasCacheValidityDecidingFile(FilePath workspace) throws IOException, InterruptedException {
-        return cacheValidityDecidingFile != null;
+    private boolean isCacheValidityDecidingFileConfigured() {
+        return StringUtils.isNotEmpty(cacheValidityDecidingFile);
     }
 
     private ObjectPath resolvePreviousCacheValidityDecidingFileHashFile(ObjectPath cachesRoot) throws IOException, InterruptedException {
@@ -261,7 +261,7 @@ public class ArbitraryFileCache extends Cache {
                 return;
             }
 
-            if (hasCacheValidityDecidingFile(workspace) && !isCacheOutdated(cachesRoot, workspace)) {
+            if (isCacheValidityDecidingFileConfigured() && !isCacheOutdated(cachesRoot, workspace)) {
                 logMessage("Skip cache creation as the cache is up-to-date", listener);
                 return;
             }
@@ -270,7 +270,7 @@ public class ArbitraryFileCache extends Cache {
 
             logMessage("Creating cache...", listener);
             compressionMethod.getCacheStrategy().cache(resolvedPath, includes, excludes, useDefaultExcludes, cache, workspace);
-            if (cacheValidityDecidingFile != null) {
+            if (isCacheValidityDecidingFileConfigured()) {
                 updateSkipCacheTriggerFileHash(cachesRoot, workspace);
             }
         }


### PR DESCRIPTION
Fixed the usage of multiple caches while using the S3 storage by not closing the S3 client after transferring files to S3. Fixes #38.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
