### PR TITLE
Remove unused S3 retry parameters

### DIFF
--- a/src/main/java/jenkins/plugins/itemstorage/s3/NonAWSS3ItemStorage.java
+++ b/src/main/java/jenkins/plugins/itemstorage/s3/NonAWSS3ItemStorage.java
@@ -118,14 +118,14 @@ public class NonAWSS3ItemStorage extends ItemStorage<S3ObjectPath> {
 
     @Override
     public S3ObjectPath getObjectPath(Item item, String path) {
-        S3Profile profile = new S3Profile(lookupCredentials(), endpoint, signerVersion, pathStyleAccess, parallelDownloads, 5, 5L);
+        S3Profile profile = new S3Profile(lookupCredentials(), endpoint, signerVersion, pathStyleAccess, parallelDownloads);
 
         return new S3ObjectPath(profile, bucketName, region, item.getFullName(), path);
     }
 
     @Override
     public S3ObjectPath getObjectPathForBranch(Item item, String path, String branch) {
-        S3Profile profile = new S3Profile(lookupCredentials(), endpoint, signerVersion, pathStyleAccess, parallelDownloads, 5, 5L);
+        S3Profile profile = new S3Profile(lookupCredentials(), endpoint, signerVersion, pathStyleAccess, parallelDownloads);
 
         String branchPath = new File(item.getFullName()).getParent() + "/" + branch;
 
@@ -183,7 +183,7 @@ public class NonAWSS3ItemStorage extends ItemStorage<S3ObjectPath> {
                 return;
             }
 
-            S3Profile profile = new S3Profile(s3Storage.lookupCredentials(), s3Storage.getEndpoint(), s3Storage.getSignerVersion(), s3Storage.getPathStyleAccess(), s3Storage.getParallelDownloads(), 5, 5L);
+            S3Profile profile = new S3Profile(s3Storage.lookupCredentials(), s3Storage.getEndpoint(), s3Storage.getSignerVersion(), s3Storage.getPathStyleAccess(), s3Storage.getParallelDownloads());
             profile.delete(s3Storage.bucketName, item.getFullName());
         }
 
@@ -195,7 +195,7 @@ public class NonAWSS3ItemStorage extends ItemStorage<S3ObjectPath> {
                 return;
             }
 
-            S3Profile profile = new S3Profile(s3Storage.lookupCredentials(), s3Storage.getEndpoint(), s3Storage.getSignerVersion(), s3Storage.getPathStyleAccess(), s3Storage.getParallelDownloads(), 5, 5L);
+            S3Profile profile = new S3Profile(s3Storage.lookupCredentials(), s3Storage.getEndpoint(), s3Storage.getSignerVersion(), s3Storage.getPathStyleAccess(), s3Storage.getParallelDownloads());
             profile.rename(s3Storage.bucketName, oldFullName, newFullName);
         }
 

--- a/src/main/java/jenkins/plugins/itemstorage/s3/S3ItemStorage.java
+++ b/src/main/java/jenkins/plugins/itemstorage/s3/S3ItemStorage.java
@@ -82,14 +82,14 @@ public class S3ItemStorage extends ItemStorage<S3ObjectPath> {
 
     @Override
     public S3ObjectPath getObjectPath(Item item, String path) {
-        S3Profile profile = new S3Profile(lookupCredentials(), null, null, false, true, 5, 5L);
+        S3Profile profile = new S3Profile(lookupCredentials(), null, null, false, true);
 
         return new S3ObjectPath(profile, bucketName, region, item.getFullName(), path);
     }
 
     @Override
     public S3ObjectPath getObjectPathForBranch(Item item, String path, String branch) {
-        S3Profile profile = new S3Profile(lookupCredentials(), null, null, false, true, 5, 5L);
+        S3Profile profile = new S3Profile(lookupCredentials(), null, null, false, true);
         String branchPath = new File(item.getFullName()).getParent() + "/" + branch;
 
         return new S3ObjectPath(profile, bucketName, region, branchPath, path);
@@ -144,7 +144,7 @@ public class S3ItemStorage extends ItemStorage<S3ObjectPath> {
 
             if (s3Storage == null) return;
 
-            S3Profile profile = new S3Profile(s3Storage.lookupCredentials(), null, null, false, true, 5, 5L);
+            S3Profile profile = new S3Profile(s3Storage.lookupCredentials(), null, null, false, true);
             profile.delete(s3Storage.bucketName, item.getFullName());
         }
 
@@ -156,7 +156,7 @@ public class S3ItemStorage extends ItemStorage<S3ObjectPath> {
                 return;
             }
 
-            S3Profile profile = new S3Profile(s3Storage.lookupCredentials(), null, null, false, true, 5, 5L);
+            S3Profile profile = new S3Profile(s3Storage.lookupCredentials(), null, null, false, true);
             profile.rename(s3Storage.bucketName, oldFullName, newFullName);
         }
 

--- a/src/main/java/jenkins/plugins/itemstorage/s3/S3Profile.java
+++ b/src/main/java/jenkins/plugins/itemstorage/s3/S3Profile.java
@@ -47,15 +47,12 @@ import java.util.Map;
  * @author Peter Hayes
  */
 public class S3Profile {
+
     private final ClientHelper helper;
-    private final int maxRetries;
-    private final long retryTime;
 
     @DataBoundConstructor
-    public S3Profile(AmazonWebServicesCredentials credentials, String endpoint, String signerVersion, boolean pathStyleAccess, boolean parallelDownloads, Integer maxRetries, Long retryTime) {
+    public S3Profile(AmazonWebServicesCredentials credentials, String endpoint, String signerVersion, boolean pathStyleAccess, boolean parallelDownloads) {
         this.helper = new ClientHelper(credentials != null ? credentials.getCredentials() : null, endpoint, null, getProxy(), signerVersion, pathStyleAccess, parallelDownloads);
-        this.maxRetries = maxRetries != null ? maxRetries : 5;
-        this.retryTime = retryTime != null ? retryTime : 5L;
     }
 
     public void upload(String bucketName,


### PR DESCRIPTION
The used Amazon S3 client performs retries already by default.

This fixes #43.