### PR TITLE
Speed up test execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,6 @@
         <aws-credentials.version>1.29</aws-credentials.version>
         <jsr305.version>3.0.2</jsr305.version>
         <assertj-core.version>3.23.1</assertj-core.version>
-        <pipeline-project-env.version>35.v5cf2c7272df2</pipeline-project-env.version>
     </properties>
 
     <name>Jenkins Job Cacher plugin</name>
@@ -115,12 +114,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.jenkins.plugins</groupId>
-            <artifactId>pipeline-project-env</artifactId>
-            <version>${pipeline-project-env.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/jenkins/plugins/jobcacher/ArbitraryFileCachePipelineTest.java
+++ b/src/test/java/jenkins/plugins/jobcacher/ArbitraryFileCachePipelineTest.java
@@ -9,8 +9,8 @@ import org.apache.commons.lang3.SystemUtils;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.Before;
-import org.junit.Rule;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.recipes.WithTimeout;
@@ -23,13 +23,13 @@ public class ArbitraryFileCachePipelineTest {
 
     private static final String DEFAULT_CACHE_VALIDITY_DECIDING_FILE_CONTENT = "abcdefghijklmnopqrstuvwxyz";
 
-    @Rule
-    public JenkinsRule jenkins = new JenkinsRule();
+    @ClassRule
+    public static JenkinsRule jenkins = new JenkinsRule();
 
-    private DumbSlave agent;
+    private static DumbSlave agent;
 
-    @Before
-    public void startAgent() throws Exception {
+    @BeforeClass
+    public static void startAgent() throws Exception {
         agent = jenkins.createSlave(Label.get("test-agent"));
     }
 

--- a/src/test/java/jenkins/plugins/jobcacher/ArbitraryFileCacheWrapperTest.java
+++ b/src/test/java/jenkins/plugins/jobcacher/ArbitraryFileCacheWrapperTest.java
@@ -2,7 +2,7 @@ package jenkins.plugins.jobcacher;
 
 import hudson.model.FreeStyleProject;
 import jenkins.plugins.jobcacher.ArbitraryFileCache.CompressionMethod;
-import org.junit.Rule;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
@@ -13,15 +13,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class ArbitraryFileCacheWrapperTest {
 
-    @Rule
-    public JenkinsRule jenkinsRule = new JenkinsRule();
+    @ClassRule
+    public static JenkinsRule jenkins = new JenkinsRule();
 
     @Test
     public void testArbitraryFileCacheForm() throws Exception {
         FreeStyleProject project = createProjectWithFullyConfiguredArbitraryFileCache("test");
         String projectConfigXml = project.getConfigFile().asString();
 
-        jenkinsRule.configRoundtrip(project);
+        jenkins.configRoundtrip(project);
         String projectConfigXmlAfterConfigRoundtrip = project.getConfigFile().asString();
 
         assertThat(projectConfigXmlAfterConfigRoundtrip).isEqualTo(projectConfigXml);
@@ -36,12 +36,11 @@ public class ArbitraryFileCacheWrapperTest {
         CacheWrapper cacheWrapper = new CacheWrapper(999, Collections.singletonList(cache));
         cacheWrapper.setDefaultBranch("develop");
 
-        FreeStyleProject project = jenkinsRule.createProject(FreeStyleProject.class, name);
+        FreeStyleProject project = jenkins.createProject(FreeStyleProject.class, name);
         project.setDescription("description");
         project.getBuildWrappersList().add(cacheWrapper);
         project.setAssignedLabel(null);
 
         return project;
     }
-
 }

--- a/src/test/resources/jenkins/plugins/jobcacher/package.json
+++ b/src/test/resources/jenkins/plugins/jobcacher/package.json
@@ -1,7 +1,0 @@
-{
-  "name": "jobcacher-test",
-  "version": "1.0.0",
-  "dependencies": {
-    "lodash": "4.17.21"
-  }
-}

--- a/src/test/resources/jenkins/plugins/jobcacher/project-env.toml
+++ b/src/test/resources/jenkins/plugins/jobcacher/project-env.toml
@@ -1,4 +1,0 @@
-tools_directory = ".tools"
-
-[nodejs]
-version = "17.2.0"


### PR DESCRIPTION
This reduces the test execution time on Linux for `ArbitraryFileCachePipelineTest` from ~102s to ~11s locally for me.