### PR TITLE
Remove deprecated java.level

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,6 @@
         <jenkins-tools-bom.artifactId>bom-2.303.x</jenkins-tools-bom.artifactId>
         <jenkins-tools-bom.version>987.v4ade2e49fe70</jenkins-tools-bom.version>
 
-        <java.level>8</java.level>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
 
         <aws-java-sdk.version>1.12.215-339.vdc07efc5320c</aws-java-sdk.version>


### PR DESCRIPTION
Starting from [POM 4.40](https://github.com/jenkinsci/plugin-pom/releases/tag/plugin-4.40) `java.level` is deprecated and should be removed from plugin POMs.

------------------------

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
