### PR TITLE
integrate pipeline-cache-plugin

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipeline/cache/CacheStepExecution.java
+++ b/src/main/java/io/jenkins/plugins/pipeline/cache/CacheStepExecution.java
@@ -1,0 +1,83 @@
+package io.jenkins.plugins.pipeline.cache;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
+import org.jenkinsci.plugins.workflow.steps.GeneralNonBlockingStepExecution;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+
+import hudson.FilePath;
+import hudson.model.TaskListener;
+import io.jenkins.plugins.pipeline.cache.agent.BackupCallable;
+import io.jenkins.plugins.pipeline.cache.agent.RestoreCallable;
+import jenkins.plugins.itemstorage.GlobalItemStorage;
+import jenkins.plugins.itemstorage.ItemStorage;
+
+/**
+ * Executes pipeline step 'cache'.
+ */
+public class CacheStepExecution extends GeneralNonBlockingStepExecution {
+
+    private static final long serialVersionUID = 1L;
+
+    private final transient PrintStream logger;
+    private final String path;
+    private final String key;
+    private final String[] restoreKeys;
+    private final String filter;
+    private final ItemStorage<?> config;
+
+    public CacheStepExecution(
+            StepContext context,
+            String path,
+            String key,
+            String[] restoreKeys,
+            String filter) throws IOException, InterruptedException {
+        super(context);
+        this.path = path;
+        this.key = key;
+        this.restoreKeys = restoreKeys;
+        this.filter = filter;
+        this.logger = context.get(TaskListener.class).getLogger();
+        this.config = GlobalItemStorage.get().getStorage();
+    }
+
+    @Override
+    public boolean start() throws Exception {
+        FilePath workspace = getContext().get(FilePath.class);
+        FilePath path = workspace.child(this.path);
+        String[] restoreKeys = Stream.concat(
+                        Stream.of(this.key),
+                        Stream.of(Optional.ofNullable(this.restoreKeys).orElse(new String[0]))
+                ).toArray(String[]::new);
+
+        // restore existing cache
+        path.act(new RestoreCallable(config, restoreKeys)).printInfos(logger);
+
+        // execute inner-step and save cache afterwards
+        getContext().newBodyInvoker().withCallback(new BodyExecutionCallback() {
+            @Override
+            public void onSuccess(StepContext context, Object result) {
+                try {
+                    path.act(new BackupCallable(config, key, filter)).printInfos(logger);
+                } catch (Exception x) {
+                    context.onFailure(x);
+                    return;
+                }
+                context.onSuccess(result);
+            }
+
+            @Override
+            public void onFailure(StepContext context, Throwable t) {
+                logger.println("Cache not saved (inner-step execution failed)");
+                context.onFailure(t);
+            }
+        }).start();
+
+        return false;
+    }
+
+}

--- a/src/main/java/io/jenkins/plugins/pipeline/cache/CacheStepExecution.java
+++ b/src/main/java/io/jenkins/plugins/pipeline/cache/CacheStepExecution.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.pipeline.cache;
 
 import java.io.IOException;
 import java.io.PrintStream;
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -39,7 +40,7 @@ public class CacheStepExecution extends GeneralNonBlockingStepExecution {
         super(context);
         this.path = path;
         this.key = key;
-        this.restoreKeys = restoreKeys;
+        this.restoreKeys = restoreKeys == null ? null : Arrays.copyOf(restoreKeys, restoreKeys.length);
         this.filter = filter;
         this.logger = context.get(TaskListener.class).getLogger();
         this.config = GlobalItemStorage.get().getStorage();

--- a/src/main/java/io/jenkins/plugins/pipeline/cache/agent/AbstractMasterToAgentS3Callable.java
+++ b/src/main/java/io/jenkins/plugins/pipeline/cache/agent/AbstractMasterToAgentS3Callable.java
@@ -5,8 +5,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.cloudbees.jenkins.plugins.awscredentials.AmazonWebServicesCredentials;
-
 import io.jenkins.cli.shaded.org.apache.commons.lang.NotImplementedException;
 import io.jenkins.plugins.pipeline.cache.s3.CacheItemRepository;
 import io.jenkins.plugins.pipeline.cache.s3.S3Config;
@@ -25,10 +23,8 @@ public abstract class AbstractMasterToAgentS3Callable extends MasterToSlaveFileC
     protected AbstractMasterToAgentS3Callable(ItemStorage<?> storage) {
         if (storage instanceof NonAWSS3ItemStorage) {
             NonAWSS3ItemStorage nonAWSS3ItemStorage = (NonAWSS3ItemStorage) storage;
-            AmazonWebServicesCredentials credentials = nonAWSS3ItemStorage.lookupCredentials();
             this.s3Config = new S3Config(
-                    credentials.getCredentials().getAWSAccessKeyId(),
-                    credentials.getCredentials().getAWSSecretKey(),
+                    nonAWSS3ItemStorage.lookupCredentials(),
                     nonAWSS3ItemStorage.getRegion(),
                     nonAWSS3ItemStorage.getEndpoint(),
                     nonAWSS3ItemStorage.getBucketName()

--- a/src/main/java/io/jenkins/plugins/pipeline/cache/agent/AbstractMasterToAgentS3Callable.java
+++ b/src/main/java/io/jenkins/plugins/pipeline/cache/agent/AbstractMasterToAgentS3Callable.java
@@ -1,0 +1,103 @@
+package io.jenkins.plugins.pipeline.cache.agent;
+
+import java.io.PrintStream;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.cloudbees.jenkins.plugins.awscredentials.AmazonWebServicesCredentials;
+
+import io.jenkins.cli.shaded.org.apache.commons.lang.NotImplementedException;
+import io.jenkins.plugins.pipeline.cache.s3.CacheItemRepository;
+import io.jenkins.plugins.pipeline.cache.s3.S3Config;
+import jenkins.MasterToSlaveFileCallable;
+import jenkins.plugins.itemstorage.ItemStorage;
+import jenkins.plugins.itemstorage.s3.NonAWSS3ItemStorage;
+
+/**
+ * Base class for S3 related operations. Note: The class is constructed on the master node but method are executed on the agent.
+ */
+public abstract class AbstractMasterToAgentS3Callable extends MasterToSlaveFileCallable<AbstractMasterToAgentS3Callable.Result> {
+
+    private final S3Config s3Config;
+    private volatile CacheItemRepository cacheItemRepository;
+
+    protected AbstractMasterToAgentS3Callable(ItemStorage<?> storage) {
+        if (storage instanceof NonAWSS3ItemStorage) {
+            NonAWSS3ItemStorage nonAWSS3ItemStorage = (NonAWSS3ItemStorage) storage;
+            AmazonWebServicesCredentials credentials = nonAWSS3ItemStorage.lookupCredentials();
+            this.s3Config = new S3Config(
+                    credentials.getCredentials().getAWSAccessKeyId(),
+                    credentials.getCredentials().getAWSSecretKey(),
+                    nonAWSS3ItemStorage.getRegion(),
+                    nonAWSS3ItemStorage.getEndpoint(),
+                    nonAWSS3ItemStorage.getBucketName()
+            );
+        } else {
+            throw new NotImplementedException(storage.getClass().getSimpleName() + " is not supported yet!");
+        }
+    }
+
+    protected CacheItemRepository cacheItemRepository() {
+        if (cacheItemRepository == null) {
+            synchronized (this) {
+                cacheItemRepository = new CacheItemRepository(s3Config);
+            }
+        }
+
+        return cacheItemRepository;
+    }
+
+    public static class ResultBuilder {
+
+        private Result result = new Result();
+
+        /**
+         * Creates a new Result object.
+         */
+        public Result build() {
+            Result build = new Result();
+            build.infos = new ArrayList<>(result.infos);
+            return build;
+        }
+
+        /**
+         * Adds a given info message to the result.
+         */
+        public ResultBuilder withInfo(String s) {
+            result.addInfo(s);
+            return this;
+        }
+    }
+
+    protected String performanceString(String key, long startNanoTime) {
+        double duration = (System.nanoTime() - startNanoTime) / 1000000000D;
+        long size = cacheItemRepository().getContentLength(key);
+        long speed = (long) (size / duration);
+        return String.format("%s bytes in %.2f secs (%s bytes/sec)", size, duration, speed);
+    }
+
+    /**
+     * Result object.
+     */
+    public static class Result implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private List<String> infos = new ArrayList<>();
+
+        /**
+         * Adds a given info message to the result.
+         */
+        public void addInfo(String s) {
+            infos.add(s);
+        }
+
+        /**
+         * Prints out all the info messages to the given logger.
+         */
+        public void printInfos(PrintStream logger) {
+            infos.forEach(logger::println);
+        }
+    }
+
+}

--- a/src/main/java/io/jenkins/plugins/pipeline/cache/agent/BackupCallable.java
+++ b/src/main/java/io/jenkins/plugins/pipeline/cache/agent/BackupCallable.java
@@ -1,0 +1,65 @@
+package io.jenkins.plugins.pipeline.cache.agent;
+
+import static java.lang.String.format;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import hudson.FilePath;
+import hudson.remoting.VirtualChannel;
+import jenkins.plugins.itemstorage.ItemStorage;
+
+/**
+ * Creates a tar archive of a given {@link FilePath} and uploads it to S3.
+ */
+public class BackupCallable extends AbstractMasterToAgentS3Callable {
+    private final String key;
+    private final String filter;
+
+    /**
+     * @param config S3 instance and bucket name
+     * @param key the key used for this backup
+     * @param filter Ant file pattern mask, like <b>**&#47;*.java</b> which is applied to the path.
+     */
+    public BackupCallable(ItemStorage<?> config, String key, String filter) {
+        super(config);
+        this.key = key;
+        this.filter = filter == null || filter.isEmpty() ? "**/*" : filter;
+    }
+
+    @Override
+    public Result invoke(File path, VirtualChannel channel) throws IOException, InterruptedException {
+        // make sure that path exists
+        if (!path.exists()) {
+            return new ResultBuilder()
+                    .withInfo("Cache not saved (path not exists)")
+                    .build();
+        }
+
+        // make sure that path is a directory
+        else if (!path.isDirectory()) {
+            return new ResultBuilder()
+                    .withInfo("Cache not saved (path is not a directory)")
+                    .build();
+        }
+
+        // make sure that cache not exists yet
+        if (cacheItemRepository().exists(key)) {
+            return new ResultBuilder()
+                    .withInfo(format("Cache not saved (%s already exists)", key))
+                    .build();
+        }
+
+        // do backup
+        long start = System.nanoTime();
+        try (OutputStream out = cacheItemRepository().createObjectOutputStream(key)) {
+            new FilePath(path).tar(out, filter);
+        }
+        return new ResultBuilder()
+                .withInfo(format("Cache saved successfully (%s)", key))
+                .withInfo(performanceString(key, start))
+                .build();
+    }
+
+}

--- a/src/main/java/io/jenkins/plugins/pipeline/cache/agent/RestoreCallable.java
+++ b/src/main/java/io/jenkins/plugins/pipeline/cache/agent/RestoreCallable.java
@@ -1,0 +1,59 @@
+package io.jenkins.plugins.pipeline.cache.agent;
+
+import static java.lang.String.format;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+import com.amazonaws.services.s3.model.S3Object;
+
+import hudson.FilePath;
+import hudson.remoting.VirtualChannel;
+import jenkins.plugins.itemstorage.ItemStorage;
+
+/**
+ * Extracts an existing tar archive from S3 to a given {@link FilePath}.
+ */
+public class RestoreCallable extends AbstractMasterToAgentS3Callable {
+    private final String[] restoreKeys;
+
+    public RestoreCallable(ItemStorage<?> config, String... restoreKeys) {
+        super(config);
+        this.restoreKeys = restoreKeys;
+    }
+
+    @Override
+    public Result invoke(File path, VirtualChannel channel) throws IOException, InterruptedException {
+        // make sure that the restore path not exists yet or is a directory
+        if (path.exists() && !path.isDirectory()) {
+            return new ResultBuilder()
+                    .withInfo("Cache not restored (path is not a directory)")
+                    .build();
+        }
+
+        String key = cacheItemRepository().findKeyByRestoreKeys(restoreKeys);
+
+        // make sure that the cache exists
+        if (key == null) {
+            return new ResultBuilder()
+                    .withInfo("Cache not restored (no such key found)")
+                    .build();
+        }
+
+        // do restore
+        long startNanoTime = System.nanoTime();
+        try (S3Object s3Object = cacheItemRepository().getS3Object(key);
+             InputStream is = s3Object.getObjectContent()) {
+            new FilePath(path).untarFrom(is, FilePath.TarCompression.NONE);
+            // update last access timestamp
+            cacheItemRepository().updateLastAccess(s3Object);
+        }
+        return new ResultBuilder()
+                .withInfo(format("Cache restored successfully (%s)", key))
+                .withInfo(performanceString(key, startNanoTime))
+                .build();
+    }
+
+
+}

--- a/src/main/java/io/jenkins/plugins/pipeline/cache/hash/HashFilesStep.java
+++ b/src/main/java/io/jenkins/plugins/pipeline/cache/hash/HashFilesStep.java
@@ -1,0 +1,57 @@
+package io.jenkins.plugins.pipeline.cache.hash;
+
+import java.util.Set;
+
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import com.google.common.collect.ImmutableSet;
+
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.model.TaskListener;
+
+/**
+ * Handles the 'hashFiles' step execution. When for example <b>hashFiles('**&#47;pom.xml')</b> is called from the pipeline then all
+ * the poms of the project are hashed and this value is then returned.
+ * @see HashFilesStepExecution
+ */
+public class HashFilesStep extends Step {
+
+    private final String pattern;
+
+    /**
+     * @param pattern Glob pattern to filter workspace files (e.g. **&#47;pom.xml)
+     */
+    @DataBoundConstructor
+    public HashFilesStep(String pattern) {
+        this.pattern = pattern;
+    }
+
+    @Override
+    public StepExecution start(StepContext context) {
+        return new HashFilesStepExecution(context, pattern);
+    }
+
+    @Extension
+    public static class DescriptorImpl extends StepDescriptor {
+
+        @Override
+        public Set<? extends Class<?>> getRequiredContext() {
+            return ImmutableSet.of(TaskListener.class, FilePath.class);
+        }
+
+        @Override
+        public String getFunctionName() {
+            return "hashFiles";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "creates a hash from workspace files";
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/pipeline/cache/hash/HashFilesStepExecution.java
+++ b/src/main/java/io/jenkins/plugins/pipeline/cache/hash/HashFilesStepExecution.java
@@ -1,0 +1,45 @@
+package io.jenkins.plugins.pipeline.cache.hash;
+
+import java.io.InputStream;
+import java.io.SequenceInputStream;
+import java.util.Arrays;
+import java.util.Iterator;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.collections.IteratorUtils;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
+
+import hudson.FilePath;
+
+/**
+ * Collects selected files, creates one hash for all files and returns the hash as result value. If there are no files selected at all
+ * then d41d8cd98f00b204e9800998ecf8427e is returned (md5 hash of an empty string).
+ */
+public class HashFilesStepExecution extends SynchronousNonBlockingStepExecution<String> {
+    private final String pattern;
+
+    public HashFilesStepExecution(StepContext context, String pattern) {
+        super(context);
+        this.pattern = pattern;
+    }
+
+    @Override
+    protected String run() throws Exception {
+        FilePath workspace = getContext().get(FilePath.class);
+        Iterator<InputStream> files = Arrays.stream(workspace.list(pattern))
+                .sorted()
+                .map(filePath -> {
+                    try {
+                        return filePath.read();
+                    } catch (Exception e) {
+                        throw new IllegalStateException(e);
+                    }
+                })
+                .iterator();
+
+        try (SequenceInputStream sequenceInputStream = new SequenceInputStream(IteratorUtils.asEnumeration(files))) {
+            return DigestUtils.md5Hex(sequenceInputStream);
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/pipeline/cache/s3/CacheItem.java
+++ b/src/main/java/io/jenkins/plugins/pipeline/cache/s3/CacheItem.java
@@ -1,0 +1,40 @@
+package io.jenkins.plugins.pipeline.cache.s3;
+
+/**
+ * Represents a cache item.
+ */
+public class CacheItem {
+    private final String key;
+    private final long contentLength;
+    private final long lastAccess;
+    private final long lastModified;
+
+    /**
+     * @param key Unique identifier (e.g. maven-d41d8cd98f00b204e9800998ecf8427e)
+     * @param contentLength Size of the cache in byte
+     * @param lastAccess Unix time in ms when the cache was accessed last
+     * @param lastModified Unix time in ms when the cache was modified last
+     */
+    public CacheItem(String key, long contentLength, long lastAccess, long lastModified) {
+        this.key = key;
+        this.contentLength = contentLength;
+        this.lastAccess = lastAccess;
+        this.lastModified = lastModified;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public long getContentLength() {
+        return contentLength;
+    }
+
+    public long getLastAccess() {
+        return lastAccess;
+    }
+
+    public long getLastModified() {
+        return lastModified;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/pipeline/cache/s3/CacheItemRepository.java
+++ b/src/main/java/io/jenkins/plugins/pipeline/cache/s3/CacheItemRepository.java
@@ -1,0 +1,229 @@
+package io.jenkins.plugins.pipeline.cache.s3;
+
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.CopyObjectRequest;
+import com.amazonaws.services.s3.model.DeleteObjectsRequest;
+import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.HeadBucketRequest;
+import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+
+public class CacheItemRepository {
+
+    private static final String LAST_ACCESS = "LAST_ACCESS";
+
+    private final AmazonS3 s3;
+    private final String bucket;
+
+    public CacheItemRepository(S3Config config) {
+        this.s3 = createS3Client(config);
+        this.bucket = config.getBucket();
+    }
+
+    protected AmazonS3 createS3Client(S3Config config) {
+        return AmazonS3ClientBuilder
+                .standard()
+                .withPathStyleAccessEnabled(true)
+                .withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(config.getUsername(), config.getPassword())))
+                .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(config.getEndpoint(), config.getRegion()))
+                .build();
+    }
+
+    /**
+     * Provides the total size of all cache items.
+     */
+    public long getTotalCacheSize() {
+        return Stream.of(s3.listObjects(bucket))
+                .flatMap(this::truncateSize)
+                .reduce(Long::sum)
+                .orElse(0L);
+    }
+
+    /**
+     * Provides a stream of all cache items.
+     */
+    public Stream<CacheItem> findAll() {
+        return truncateCacheItems(s3.listObjects(bucket));
+    }
+
+    /**
+     * Removes items from the cache.
+     * @param keys Stream of keys which should be removed
+     * @return count of removed items
+     */
+    public int delete(Stream<String> keys) {
+        return s3.deleteObjects(new DeleteObjectsRequest(bucket)
+                .withKeys(keys.toArray(String[]::new))
+        ).getDeletedObjects()
+                .size();
+    }
+
+    /**
+     * Provides the size of a cache item in byte.
+     */
+    public long getContentLength(String key) {
+        return s3.getObjectMetadata(bucket, key).getContentLength();
+    }
+
+    /**
+     * Provides the {@link S3Object} assigned to a given key or null if it not exists.
+     */
+    public S3Object getS3Object(String key) {
+        return s3.getObject(new GetObjectRequest(bucket, key));
+    }
+
+    /**
+     * Updates the last access timestamp of a given {@link S3Object}.
+     */
+    public void updateLastAccess(S3Object s3Object) {
+        ObjectMetadata metadataCopy = s3Object.getObjectMetadata();
+        updateLastAccess(metadataCopy);
+
+        s3.copyObject(new CopyObjectRequest(bucket, s3Object.getKey(), bucket, s3Object.getKey())
+                .withNewObjectMetadata(metadataCopy));
+    }
+
+    /**
+     * Updates the last access timestamp of a given {@link ObjectMetadata} <b>but it will not be persisted</b>.
+     */
+    public static void updateLastAccess(ObjectMetadata metadata) {
+        metadata.addUserMetadata(LAST_ACCESS, Long.toString(System.currentTimeMillis()));
+    }
+
+    /**
+     * Finds the best matching key by a given list of restoreKeys. Note, that restoreKeys doesn't have to be necessarily existing
+     * keys. They can also just be prefixes of existing keys. If there is no matching key found at all then null is returned.
+     */
+    public String findKeyByRestoreKeys(String... restoreKeys) {
+        if (restoreKeys == null) {
+            return null;
+        }
+
+        // 1. try exact match
+        for (String restoreKey : restoreKeys) {
+            if (exists(restoreKey)) {
+                return restoreKey;
+            }
+        }
+
+        // 2. try prefix match
+        return Arrays.stream(restoreKeys)
+                .map(this::findKeyByPrefix)
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
+     * Returns true if the object with the given exists, otherwise false.
+     */
+    public boolean exists(String key) {
+        return s3.doesObjectExist(bucket, key);
+    }
+
+    /**
+     * Creates an {@link OutputStream} for a given key. This can be used to write data directly to an object in S3.
+     */
+    public OutputStream createObjectOutputStream(String key) {
+        return new S3OutputStream(s3, bucket, key);
+    }
+
+    /**
+     * Returns true if the bucket exists and is accessible, otherwise false.
+     */
+    public boolean bucketExists() {
+        try {
+            s3.headBucket(new HeadBucketRequest(bucket));
+            return true;
+        } catch (AmazonServiceException e) {
+            if (e.getStatusCode() == 404) {
+                return false;
+            }
+            throw e;
+        }
+    }
+
+    private Stream<CacheItem> truncateCacheItems(ObjectListing listing) {
+        return truncate(listing, this::mapToCacheItems);
+    }
+
+    private <R> Stream<R> truncate(ObjectListing listing, Function<ObjectListing, Stream<R>> transform) {
+        if (listing.isTruncated()) {
+            return Stream.concat(
+                    transform.apply(listing),
+                    truncate(s3.listNextBatchOfObjects(listing), transform)
+            );
+        }
+        return transform.apply(listing);
+    }
+
+    private Stream<CacheItem> mapToCacheItems(ObjectListing listing) {
+        return listing.getObjectSummaries().stream()
+                .map(this::mapToCacheItem);
+    }
+
+    private CacheItem mapToCacheItem(S3ObjectSummary s3ObjectSummary) {
+        ObjectMetadata metadata = s3.getObjectMetadata(bucket, s3ObjectSummary.getKey());
+        return new CacheItem(
+                s3ObjectSummary.getKey(),
+                metadata.getContentLength(),
+                mapToLastAccess(metadata),
+                s3ObjectSummary.getLastModified().getTime()
+        );
+    }
+
+    private Stream<Long> truncateSize(ObjectListing listing) {
+        return truncate(listing, this::mapToSize);
+    }
+
+    private Stream<Long> mapToSize(ObjectListing listing) {
+        return listing.getObjectSummaries().stream().map(S3ObjectSummary::getSize);
+    }
+
+    private Long mapToLastAccess(ObjectMetadata objectMetadata) {
+        if (!objectMetadata.getUserMetadata().containsKey(LAST_ACCESS)) {
+            return 0L;
+        }
+
+        return Long.valueOf(objectMetadata.getUserMetadata().get(LAST_ACCESS));
+    }
+
+    private String findKeyByPrefix(String prefix) {
+        if (prefix == null || prefix.isEmpty()) {
+            return null;
+        }
+
+        ObjectListing listing = s3.listObjects(bucket, prefix);
+
+        // 1. no matching key at all
+        if (listing.getObjectSummaries().isEmpty()) {
+            return null;
+        }
+
+        // 2. there is one key with the same prefix
+        if (listing.getObjectSummaries().size() == 1) {
+            return listing.getObjectSummaries().get(0).getKey();
+        }
+
+        // 3. there are more than one keys with the same prefix -> return the latest one
+        return truncateCacheItems(listing)
+                .sorted(Comparator.comparing(CacheItem::getLastModified).reversed())
+                .map(CacheItem::getKey)
+                .findFirst().orElse(null);
+    }
+
+}

--- a/src/main/java/io/jenkins/plugins/pipeline/cache/s3/CacheItemRepository.java
+++ b/src/main/java/io/jenkins/plugins/pipeline/cache/s3/CacheItemRepository.java
@@ -8,8 +8,6 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 import com.amazonaws.AmazonServiceException;
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
@@ -38,7 +36,7 @@ public class CacheItemRepository {
         return AmazonS3ClientBuilder
                 .standard()
                 .withPathStyleAccessEnabled(true)
-                .withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(config.getUsername(), config.getPassword())))
+                .withCredentials(config.getCredentials())
                 .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(config.getEndpoint(), config.getRegion()))
                 .build();
     }

--- a/src/main/java/io/jenkins/plugins/pipeline/cache/s3/S3Config.java
+++ b/src/main/java/io/jenkins/plugins/pipeline/cache/s3/S3Config.java
@@ -2,30 +2,26 @@ package io.jenkins.plugins.pipeline.cache.s3;
 
 import java.io.Serializable;
 
+import com.amazonaws.auth.AWSCredentialsProvider;
+
 public class S3Config implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private final String username;
-    private final String password;
+    private final AWSCredentialsProvider credentials;
     private final String region;
     private final String endpoint;
     private final String bucket;
 
-    public S3Config(String username, String password, String region, String endpoint, String bucket) {
-        this.username = username;
-        this.password = password;
+    public S3Config(AWSCredentialsProvider credentials, String region, String endpoint, String bucket) {
+        this.credentials = credentials;
         this.region = region;
         this.endpoint = endpoint;
         this.bucket = bucket;
     }
 
-    public String getUsername() {
-        return username;
-    }
-
-    public String getPassword() {
-        return password;
+    public AWSCredentialsProvider getCredentials() {
+        return credentials;
     }
 
     public String getRegion() {

--- a/src/main/java/io/jenkins/plugins/pipeline/cache/s3/S3Config.java
+++ b/src/main/java/io/jenkins/plugins/pipeline/cache/s3/S3Config.java
@@ -1,0 +1,43 @@
+package io.jenkins.plugins.pipeline.cache.s3;
+
+import java.io.Serializable;
+
+public class S3Config implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String username;
+    private final String password;
+    private final String region;
+    private final String endpoint;
+    private final String bucket;
+
+    public S3Config(String username, String password, String region, String endpoint, String bucket) {
+        this.username = username;
+        this.password = password;
+        this.region = region;
+        this.endpoint = endpoint;
+        this.bucket = bucket;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public String getBucket() {
+        return bucket;
+    }
+
+}

--- a/src/main/java/io/jenkins/plugins/pipeline/cache/s3/S3OutputStream.java
+++ b/src/main/java/io/jenkins/plugins/pipeline/cache/s3/S3OutputStream.java
@@ -1,0 +1,182 @@
+package io.jenkins.plugins.pipeline.cache.s3;
+
+import java.io.ByteArrayInputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PartETag;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.UploadPartRequest;
+import com.amazonaws.services.s3.model.UploadPartResult;
+
+/**
+ * {@link OutputStream} which allows writing an object to S3 directly. Heavily inspired by
+ * https://gist.github.com/blagerweij/ad1dbb7ee2fff8bcffd372815ad310eb.
+ */
+public class S3OutputStream extends OutputStream {
+
+    /**
+     * Default chunk size is 5MB
+     */
+    protected static final int BUFFER_SIZE = 5*1024*1024;
+
+    /**
+     * The bucket-name on Amazon S3
+     */
+    private final String bucket;
+
+    /**
+     * The path (key) name within the bucket
+     */
+    private final String path;
+
+    /**
+     * The temporary buffer used for storing the chunks
+     */
+    private final byte[] buf;
+    /**
+     * Amazon S3 client.
+     */
+    private final AmazonS3 s3Client;
+    /**
+     * Collection of the etags for the parts that have been uploaded
+     */
+    private final List<PartETag> etags;
+    /**
+     * The position in the buffer
+     */
+    private int position;
+    /**
+     * The unique id for this upload
+     */
+    private String uploadId;
+    /**
+     * indicates whether the stream is still open / valid
+     */
+    private boolean open;
+
+    /**
+     * Creates a new S3 OutputStream
+     *
+     * @param s3Client the AmazonS3 client
+     * @param bucket   name of the bucket
+     * @param path     path within the bucket
+     */
+    public S3OutputStream(AmazonS3 s3Client, String bucket, String path) {
+        this.s3Client = s3Client;
+        this.bucket = bucket;
+        this.path = path;
+        this.buf = new byte[BUFFER_SIZE];
+        this.position = 0;
+        this.etags = new ArrayList<>();
+        this.open = true;
+    }
+
+    /**
+     * Write an array to the S3 output stream.
+     *
+     * @param b the byte-array to append
+     */
+    @Override
+    public void write(byte[] b) {
+        write(b, 0, b.length);
+    }
+
+    /**
+     * Writes an array to the S3 Output Stream
+     *
+     * @param byteArray the array to write
+     * @param o         the offset into the array
+     * @param l         the number of bytes to write
+     */
+    @Override
+    public void write(final byte[] byteArray, final int o, final int l) {
+        this.assertOpen();
+        int ofs = o, len = l;
+        int size;
+        while (len > (size = this.buf.length - position)) {
+            System.arraycopy(byteArray, ofs, this.buf, this.position, size);
+            this.position += size;
+            flushBufferAndRewind();
+            ofs += size;
+            len -= size;
+        }
+        System.arraycopy(byteArray, ofs, this.buf, this.position, len);
+        this.position += len;
+    }
+
+    /**
+     * Flushes the buffer by uploading a part to S3.
+     */
+    @Override
+    public synchronized void flush() {
+        this.assertOpen();
+    }
+
+    protected void flushBufferAndRewind() {
+        if (uploadId == null) {
+            ObjectMetadata metadata = new ObjectMetadata();
+            CacheItemRepository.updateLastAccess(metadata);
+            final InitiateMultipartUploadRequest request = new InitiateMultipartUploadRequest(this.bucket, this.path)
+                    .withCannedACL(CannedAccessControlList.BucketOwnerFullControl)
+                    .withObjectMetadata(metadata);
+            InitiateMultipartUploadResult initResponse = s3Client.initiateMultipartUpload(request);
+            this.uploadId = initResponse.getUploadId();
+        }
+        uploadPart();
+        this.position = 0;
+    }
+
+    protected void uploadPart() {
+        UploadPartResult uploadResult = this.s3Client.uploadPart(new UploadPartRequest()
+                .withBucketName(this.bucket)
+                .withKey(this.path)
+                .withUploadId(this.uploadId)
+                .withInputStream(new ByteArrayInputStream(buf, 0, this.position))
+                .withPartNumber(this.etags.size() + 1)
+                .withPartSize(this.position));
+        this.etags.add(uploadResult.getPartETag());
+    }
+
+    @Override
+    public void close() {
+        if (this.open) {
+            this.open = false;
+            if (this.uploadId != null) {
+                if (this.position > 0) {
+                    uploadPart();
+                }
+                this.s3Client.completeMultipartUpload(new CompleteMultipartUploadRequest(bucket, path, uploadId, etags));
+            } else {
+                final ObjectMetadata metadata = new ObjectMetadata();
+                metadata.setContentLength(this.position);
+                final PutObjectRequest request =
+                        new PutObjectRequest(this.bucket, this.path, new ByteArrayInputStream(this.buf, 0, this.position), metadata)
+                                .withCannedAcl(CannedAccessControlList.BucketOwnerFullControl);
+                this.s3Client.putObject(request);
+            }
+        }
+    }
+
+    @Override
+    public void write(int b) {
+        this.assertOpen();
+        if (position >= this.buf.length) {
+            flushBufferAndRewind();
+        }
+        this.buf[position++] = (byte) b;
+    }
+
+    private void assertOpen() {
+        if (!this.open) {
+            throw new IllegalStateException("Closed");
+        }
+    }
+}

--- a/src/main/java/jenkins/plugins/itemstorage/s3/NonAWSS3ItemStorage.java
+++ b/src/main/java/jenkins/plugins/itemstorage/s3/NonAWSS3ItemStorage.java
@@ -130,7 +130,7 @@ public class NonAWSS3ItemStorage extends ItemStorage<S3ObjectPath> {
         return new S3ObjectPath(createS3Profile(), bucketName, region, branchPath, path);
     }
 
-    private AmazonWebServicesCredentials lookupCredentials() {
+    public AmazonWebServicesCredentials lookupCredentials() {
         return (credentialsId == null) ? null : CredentialsMatchers.firstOrNull(
                 possibleCredentials(),
                 CredentialsMatchers.withId(credentialsId));

--- a/src/main/java/jenkins/plugins/jobcacher/pipeline/CacheStep.java
+++ b/src/main/java/jenkins/plugins/jobcacher/pipeline/CacheStep.java
@@ -106,7 +106,7 @@ public class CacheStep extends Step {
     public StepExecution start(StepContext context) throws Exception {
         validateProperties();
 
-        if (maxCacheSize != null || caches != null) {
+        if (maxCacheSize != null && caches != null) {
             // execute legacy cache implementation
             return new ExecutionImpl(context, maxCacheSize, caches, defaultBranch);
         }

--- a/src/test/java/io/jenkins/plugins/pipeline/cache/CacheStepMinioTest.java
+++ b/src/test/java/io/jenkins/plugins/pipeline/cache/CacheStepMinioTest.java
@@ -1,0 +1,440 @@
+package io.jenkins.plugins.pipeline.cache;
+
+import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import com.cloudbees.jenkins.plugins.awscredentials.AWSCredentialsImpl;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+
+import hudson.model.Result;
+import jenkins.plugins.itemstorage.GlobalItemStorage;
+import jenkins.plugins.itemstorage.s3.NonAWSS3ItemStorage;
+
+/**
+ * Checks that the cache step works as expected in pipelines. Each test starts with an empty bucket.
+ */
+public class CacheStepMinioTest {
+
+    @ClassRule
+    public static MinioContainer minio = new MinioContainer();
+
+    @ClassRule
+    public static MinioMcContainer mc = new MinioMcContainer(minio);
+
+    @ClassRule
+    public static BuildWatcher buildWatcher = new BuildWatcher();
+
+    @ClassRule
+    public static JenkinsRule j = new JenkinsRule();
+
+    @BeforeClass
+    public static void setupJenkins() throws Exception {
+        // execute build jobs on the agent node only
+        j.jenkins.setNumExecutors(0);
+        j.createSlave(true);
+    }
+
+    @Before
+    public void setupCache() throws Exception {
+        // create a test bucket in MinIO
+        String bucket = UUID.randomUUID().toString();
+        mc.createBucket(bucket);
+
+        // setup credentials for bucket in Jenkins
+        AWSCredentialsImpl credentials = new AWSCredentialsImpl(
+                CredentialsScope.SYSTEM,
+                "minio-test-credentials-id",
+                minio.accessKey(),
+                minio.secretKey(),
+                "minio test credentials");
+        SystemCredentialsProvider.getInstance().getCredentials().add(credentials);
+        SystemCredentialsProvider.getInstance().save();
+
+        // configure the corresponding ItemStorage in Jenkins
+        NonAWSS3ItemStorage storage = new NonAWSS3ItemStorage(
+                "minio-test-credentials-id",
+                bucket,
+                minio.getExternalAddress(),
+                "us-west-1",
+                null,
+                true,
+                true
+        );
+        GlobalItemStorage.get().setStorage(storage);
+    }
+
+    @Test
+    public void testBackupAndRestore() throws Exception {
+        // GIVEN
+        WorkflowJob jobA = createJob("node {\n" +
+                "  cache(path: '.', key: '1234') {\n" +
+                "    writeFile text: 'red-content', file: 'file'\n" +
+                "    dir ('sub') {\n" +
+                "      writeFile text: 'blue-content', file: 'file'\n" +
+                "    }\n" +
+                "  }\n" +
+                "}");
+        WorkflowJob jobB = createJob("node {\n" +
+                "  cache(path: '.', key: '1234') {\n" +
+                "    println(readFile(file: 'file'))\n" +
+                "    dir ('sub') {\n" +
+                "      println(readFile(file: 'file'))\n" +
+                "    }\n" +
+                "  }\n" +
+                "}");
+
+        // WHEN
+        WorkflowRun resultA = executeJob(jobA);
+        WorkflowRun resultB = executeJob(jobB);
+
+        // THEN
+        j.assertBuildStatusSuccess(resultA);
+        j.assertLogContains("Cache not restored (no such key found)", resultA);
+        j.assertLogContains("Cache saved successfully (1234)", resultA);
+        j.assertBuildStatusSuccess(resultB);
+        j.assertLogContains("Cache restored successfully (1234)", resultB);
+        j.assertLogContains("red-content", resultB);
+        j.assertLogContains("blue-content", resultB);
+        j.assertLogContains("Cache not saved (1234 already exists)", resultB);
+    }
+
+    @Test
+    public void testBackupIsSkippedOnError() throws Exception {
+        // GIVEN
+        WorkflowJob job = createJob("node {\n" +
+                "  cache(path: '.', key: 'a') {\n" +
+                "    error 'Program failed, please read logs...'\n" +
+                "  }\n" +
+                "}");
+
+        // WHEN
+        WorkflowRun result = executeJob(job);
+
+        // THEN
+        j.assertBuildStatus(Result.FAILURE, result);
+        j.assertLogContains("Cache not saved (inner-step execution failed)", result);
+    }
+
+    @Test
+    public void testRestoreKey() throws Exception {
+        // GIVEN
+        WorkflowJob jobA = createJob("node {\n" +
+                "  cache(path: '.', key: 'cache-a') {\n" +
+                "    writeFile text: 'my-content', file: 'file'\n" +
+                "  }\n" +
+                "}");
+        WorkflowJob jobB = createJob("node {\n" +
+                "  cache(path: '.', key: 'cache-b', restoreKeys: ['cache-a']) {}\n" +
+                "}");
+
+        // WHEN
+        WorkflowRun resultA = executeJob(jobA);
+        WorkflowRun resultB = executeJob(jobB);
+
+        // THEN
+        j.assertBuildStatusSuccess(resultA);
+        j.assertBuildStatusSuccess(resultB);
+        j.assertLogContains("Cache restored successfully (cache-a)", resultB);
+        j.assertLogContains("Cache saved successfully (cache-b)", resultB);
+    }
+
+    @Test
+    public void testRestoreKeyNotFound() throws Exception {
+        // GIVEN
+        WorkflowJob job = createJob("node {\n" +
+                "  cache(path: '.', key: 'cache-b', restoreKeys: ['cache-a']) {\n" +
+                "    writeFile file: 'file', text: 'bla'\n" +
+                "  }\n" +
+                "}");
+
+        // WHEN
+        WorkflowRun result = executeJob(job);
+
+        // THEN
+        j.assertBuildStatusSuccess(result);
+        j.assertLogContains("Cache not restored (no such key found)", result);
+        j.assertLogContains("Cache saved successfully (cache-b)", result);
+    }
+
+    @Test
+    public void testRestoreKeyPrefix() throws Exception {
+        // GIVEN
+        WorkflowJob jobA = createJob("node {\n" +
+                "  cache(path: '.', key: 'cache-a') {\n" +
+                "    writeFile text: 'my-content', file: 'file'\n" +
+                "  }\n" +
+                "}");
+        WorkflowJob jobB = createJob("node {\n" +
+                "  cache(path: '.', key: 'cache-b', restoreKeys: ['cac']) {}\n" +
+                "}");
+
+        // WHEN
+        WorkflowRun resultA = executeJob(jobA);
+        WorkflowRun resultB = executeJob(jobB);
+
+        // THEN
+        j.assertBuildStatusSuccess(resultA);
+        j.assertLogContains("Cache not restored (no such key found)", resultA);
+        j.assertLogContains("Cache saved successfully (cache-a)", resultA);
+        j.assertBuildStatusSuccess(resultB);
+        j.assertLogContains("Cache restored successfully (cache-a)", resultB);
+        j.assertLogContains("Cache saved successfully (cache-b)", resultB);
+    }
+
+    @Test
+    public void testRestoreKeyFirstOneWins() throws Exception {
+        // GIVEN
+        WorkflowJob jobA = createJob("node {\n" +
+                "  cache(path: '.', key: 'a') {\n" +
+                "    writeFile text: 'my-content', file: 'file'\n" +
+                "  }\n" +
+                "}");
+        WorkflowJob jobB = createJob("node {\n" +
+                "  cache(path: '.', key: 'b') {\n" +
+                "    writeFile text: 'my-content', file: 'file'\n" +
+                "  }\n" +
+                "}");
+        WorkflowJob jobC = createJob("node {\n" +
+                "  cache(path: '.', key: 'c') {\n" +
+                "    writeFile text: 'my-content', file: 'file'\n" +
+                "  }\n" +
+                "}");
+        WorkflowJob jobD = createJob("node {\n" +
+                "  cache(path: '.', key: 'd', restoreKeys: ['b','a','c']) {}\n" +
+                "}");
+
+        // WHEN
+        WorkflowRun resultA = executeJob(jobA);
+        WorkflowRun resultB = executeJob(jobB);
+        WorkflowRun resultC = executeJob(jobC);
+        WorkflowRun resultD = executeJob(jobD);
+
+        // THEN
+        j.assertBuildStatusSuccess(resultA);
+        j.assertBuildStatusSuccess(resultB);
+        j.assertBuildStatusSuccess(resultC);
+        j.assertBuildStatusSuccess(resultD);
+        j.assertLogContains("Cache restored successfully (b)", resultD);
+    }
+
+    @Test
+    public void testRestoreKeyExactMatchWins() throws Exception {
+        // GIVEN
+        WorkflowJob jobA = createJob("node {\n" +
+                "  cache(path: '.', key: 'cache-a') {\n" +
+                "    writeFile text: 'my-content', file: 'file'\n" +
+                "  }\n" +
+                "}");
+        WorkflowJob jobB = createJob("node {\n" +
+                "  cache(path: '.', key: 'cache-b') {\n" +
+                "    writeFile text: 'my-content', file: 'file'\n" +
+                "  }\n" +
+                "}");
+        WorkflowJob jobC = createJob("node {\n" +
+                "  cache(path: '.', key: 'cache-c') {\n" +
+                "    writeFile text: 'my-content', file: 'file'\n" +
+                "  }\n" +
+                "}");
+        WorkflowJob jobD = createJob("node {\n" +
+                "  cache(path: '.', key: 'cache', restoreKeys: ['cache-','cache-b']) {}\n" +
+                "}");
+
+        // WHEN
+        WorkflowRun resultA = executeJob(jobA);
+        WorkflowRun resultB = executeJob(jobB);
+        WorkflowRun resultC = executeJob(jobC);
+        WorkflowRun resultD = executeJob(jobD);
+
+        // THEN
+        j.assertBuildStatusSuccess(resultA);
+        j.assertBuildStatusSuccess(resultB);
+        j.assertBuildStatusSuccess(resultC);
+        j.assertBuildStatusSuccess(resultD);
+        j.assertLogContains("Cache restored successfully (cache-b)", resultD);
+    }
+
+    @Test
+    public void testRestoreKeyLatestOneWins() throws Exception {
+        // GIVEN
+        WorkflowJob jobA = createJob("node {\n" +
+                "  cache(path: '.', key: 'cache-3') {\n" +
+                "    writeFile text: 'my-content', file: 'file'\n" +
+                "  }\n" +
+                "}");
+        WorkflowJob jobB = createJob("node {\n" +
+                "  cache(path: '.', key: 'cache-1') {\n" +
+                "    writeFile text: 'my-content', file: 'file'\n" +
+                "  }\n" +
+                "}");
+        WorkflowJob jobC = createJob("node {\n" +
+                "  cache(path: '.', key: 'cache-2') {\n" +
+                "    writeFile text: 'my-content', file: 'file'\n" +
+                "  }\n" +
+                "}");
+        WorkflowJob jobD = createJob("node {\n" +
+                "  cache(path: '.', key: 'cache-4', restoreKeys: ['cache-']) {}\n" +
+                "}");
+
+        // WHEN
+        WorkflowRun resultA = executeJob(jobA);
+        WorkflowRun resultB = executeJob(jobB);
+        WorkflowRun resultC = executeJob(jobC);
+        WorkflowRun resultD = executeJob(jobD);
+
+        // THEN
+        j.assertBuildStatusSuccess(resultA);
+        j.assertBuildStatusSuccess(resultB);
+        j.assertBuildStatusSuccess(resultC);
+        j.assertBuildStatusSuccess(resultD);
+        j.assertLogContains("Cache restored successfully (cache-2)", resultD);
+    }
+
+    @Test
+    public void testKeyIsPreferredOverRestoreKey() throws Exception {
+        // GIVEN
+        WorkflowJob jobA = createJob("node {\n" +
+                "  cache(path: '.', key: 'cache-a') {\n" +
+                "    writeFile text: 'my-content', file: 'file'\n" +
+                "  }\n" +
+                "}");
+        WorkflowJob jobB = createJob("node {\n" +
+                "  cache(path: '.', key: 'cache-b') {\n" +
+                "    writeFile text: 'my-content', file: 'file'\n" +
+                "  }\n" +
+                "}");
+        WorkflowJob jobC = createJob("node {\n" +
+                "  cache(path: '.', key: 'cache-a', restoreKeys: ['cache-b']) {}\n" +
+                "}");
+
+        // WHEN
+        WorkflowRun resultA = executeJob(jobA);
+        WorkflowRun resultB = executeJob(jobB);
+        WorkflowRun resultC = executeJob(jobC);
+
+        // THEN
+        j.assertBuildStatusSuccess(resultA);
+        j.assertBuildStatusSuccess(resultB);
+        j.assertBuildStatusSuccess(resultC);
+        j.assertLogContains("Cache restored successfully (cache-a)", resultC);
+    }
+
+    @Test
+    public void testHashFiles() throws Exception {
+        // GIVEN
+        WorkflowJob job = createJob("node {\n" +
+                "  writeFile text: 'v1', file: 'pom.xml'\n" +
+                "  cache(path: '.', key: \"cache-${hashFiles('**/pom.xml')}\") {}\n" +
+                "}");
+
+        // WHEN
+        WorkflowRun result = executeJob(job);
+
+        // THEN
+        j.assertBuildStatusSuccess(result);
+        j.assertLogContains("Cache not restored (no such key found)", result);
+        j.assertLogContains("Cache saved successfully (cache-6654c734ccab8f440ff0825eb443dc7f)", result);
+    }
+
+    @Test
+    public void testHashFilesEmptyResult() throws Exception {
+        // GIVEN
+        WorkflowJob job = createJob("node {\n" +
+                "  writeFile text: 'my-content', file: 'file'\n" +
+                "  cache(path: '.', key: \"cache-${hashFiles('**/pom.xml')}\") {}\n" +
+                "}");
+
+        // WHEN
+        WorkflowRun result = executeJob(job);
+
+        // THEN
+        j.assertBuildStatusSuccess(result);
+        j.assertLogContains("Cache not restored (no such key found)", result);
+        j.assertLogContains("Cache saved successfully (cache-d41d8cd98f00b204e9800998ecf8427e)", result);
+    }
+
+    @Test
+    public void testPathNotExists() throws Exception {
+        // GIVEN
+        WorkflowJob job = createJob("node {\n" +
+                "  cache(path: '.', key: 'a') {}\n" +
+                "}");
+
+        // WHEN
+        WorkflowRun result = executeJob(job);
+
+        // THEN
+        j.assertBuildStatusSuccess(result);
+        j.assertLogContains("Cache not restored (no such key found)", result);
+        j.assertLogContains("Cache not saved (path not exists)", result);
+    }
+
+    @Test
+    public void testPathIsFile() throws Exception {
+        // GIVEN
+        WorkflowJob job = createJob("node {\n" +
+                "  writeFile file: 'file', text: 'bla'\n" +
+                "  cache(path: 'file', key: 'a') {}\n" +
+                "}");
+
+        // WHEN
+        WorkflowRun result = executeJob(job);
+
+        // THEN
+        j.assertBuildStatusSuccess(result);
+        j.assertLogContains("Cache not restored (path is not a directory)", result);
+        j.assertLogContains("Cache not saved (path is not a directory)", result);
+    }
+
+    @Test
+    public void testPathFilter() throws Exception {
+        // GIVEN
+        WorkflowJob jobA = createJob("node {\n" +
+                "  cache(path: '.', key: 'cache-a', filter: '**/*.json') {\n" +
+                "    writeFile text: 'json content', file: 'file.json'\n" +
+                "    writeFile text: 'xml content', file: 'file.xml'\n" +
+                "  }\n" +
+                "}");
+        WorkflowJob jobB = createJob("node {\n" +
+                "  cache(path: '.', key: 'cache-a') {\n" +
+                "    if (fileExists('file.json')) { echo 'file.json_exists' }\n" +
+                "    if (fileExists('file.xml')) { echo 'file.xml_exists' }\n" +
+                "  }\n" +
+                "}");
+
+        // WHEN
+        WorkflowRun resultA = executeJob(jobA);
+        WorkflowRun resultB = executeJob(jobB);
+
+        // THEN
+        j.assertBuildStatusSuccess(resultA);
+        j.assertBuildStatusSuccess(resultB);
+        j.assertLogContains("file.json_exists", resultB);
+        j.assertLogNotContains("file.xml_exists", resultB);
+    }
+
+    private WorkflowRun executeJob(WorkflowJob job) throws InterruptedException, ExecutionException {
+        WorkflowRun result = job.scheduleBuild2(0).waitForStart();
+        j.waitForCompletion(result);
+
+        return result;
+    }
+
+    private WorkflowJob createJob(String script) throws IOException {
+        WorkflowJob job = j.createProject(WorkflowJob.class);
+        job.setDefinition(new CpsFlowDefinition(script, true));
+
+        return job;
+    }
+}

--- a/src/test/java/io/jenkins/plugins/pipeline/cache/MinioContainer.java
+++ b/src/test/java/io/jenkins/plugins/pipeline/cache/MinioContainer.java
@@ -1,0 +1,38 @@
+package io.jenkins.plugins.pipeline.cache;
+
+import java.util.UUID;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+public class MinioContainer extends GenericContainer<MinioContainer> {
+
+    public MinioContainer() {
+        this("minio/minio");
+    }
+
+    public MinioContainer(String dockerImageName) {
+        super(dockerImageName);
+
+        setWaitStrategy(Wait.forHttp("/minio/health/ready").forStatusCode(200));
+
+        withEnv("MINIO_ROOT_USER", UUID.randomUUID().toString());
+        withEnv("MINIO_ROOT_PASSWORD", UUID.randomUUID().toString());
+        withCommand("server /data");
+        withExposedPorts(9000);
+        withNetwork(Network.newNetwork());  // we need a dedicated network otherwise mc cannot participate
+    }
+
+    public String accessKey() {
+        return getEnvMap().get("MINIO_ROOT_USER");
+    }
+
+    public String secretKey() {
+        return getEnvMap().get("MINIO_ROOT_PASSWORD");
+    }
+
+    public String getExternalAddress() {
+        return "http://localhost:" + getMappedPort(9000);
+    }
+}

--- a/src/test/java/io/jenkins/plugins/pipeline/cache/MinioMcContainer.java
+++ b/src/test/java/io/jenkins/plugins/pipeline/cache/MinioMcContainer.java
@@ -1,0 +1,74 @@
+package io.jenkins.plugins.pipeline.cache;
+
+import static java.lang.String.format;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import org.json.JSONObject;
+import org.testcontainers.containers.GenericContainer;
+
+import com.github.dockerjava.api.command.InspectContainerResponse;
+
+public class MinioMcContainer extends GenericContainer<MinioMcContainer> {
+
+    private final MinioContainer minio;
+
+    public MinioMcContainer(MinioContainer minio) {
+        super("minio/mc");
+        this.minio = minio;
+        dependsOn(minio);
+        withNetwork(minio.getNetwork());
+        withCreateContainerCmdModifier(c -> c.withTty(true).withEntrypoint("/bin/sh"));
+    }
+
+    @Override
+    protected void containerIsStarted(InspectContainerResponse containerInfo) {
+        try {
+            execSecure("mc config host add test-minio http://%s:9000 %s %s",
+                    minio.getNetworkAliases().get(0),
+                    minio.accessKey(),
+                    minio.secretKey());
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    public ExecResult execSecure(String command, Object... args) throws IOException, InterruptedException {
+        ExecResult result = exec(command, args);
+        if (result.getExitCode() != 0) {
+            throw new AssertionError(result.getStderr());
+        }
+        return result;
+    }
+
+    public ExecResult exec(String command, Object... args) throws IOException, InterruptedException {
+        return execInContainer("/bin/sh", "-c",  format(command, args));
+    }
+
+    public void deleteBucket(String bucket) throws IOException, InterruptedException {
+        exec("mc rb test-minio/%s --force", bucket);
+    }
+
+    public void createBucket(String bucket) throws IOException, InterruptedException {
+        execSecure("mc mb test-minio/%s", bucket);
+    }
+
+    public void createObject(String bucket, String key, String content) throws IOException, InterruptedException {
+        execSecure("echo -n \"%s\" | mc pipe test-minio/%s/%s", content, bucket, key);
+    }
+
+    public void createObject(String bucket, String key, int megabytes) throws IOException, InterruptedException {
+        execSecure("dd if=/dev/urandom of=tmp.rnd bs=1000000 count=%s", megabytes);
+        execSecure("mc cp tmp.rnd test-minio/%s/%s", bucket, key);
+    }
+
+    public void createObject(String bucket, String key) throws IOException, InterruptedException {
+        createObject(bucket, key, UUID.randomUUID().toString());
+    }
+
+    public long getBucketSize(String bucket) throws IOException, InterruptedException {
+        String result = execSecure(format("mc du --json test-minio/%s", bucket)).getStdout();
+        return Long.parseLong(new JSONObject(result).optString("size"));
+    }
+}

--- a/src/test/java/jenkins/plugins/jobcacher/MandatoryPropertiesTest.java
+++ b/src/test/java/jenkins/plugins/jobcacher/MandatoryPropertiesTest.java
@@ -1,0 +1,83 @@
+package jenkins.plugins.jobcacher;
+
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import hudson.model.Result;
+
+public class MandatoryPropertiesTest {
+
+    @ClassRule
+    public static JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void testLegacyCachesParameterIsMissing() throws Exception {
+        // GIVEN
+        WorkflowJob p = j.createProject(WorkflowJob.class);
+        p.setDefinition(new CpsFlowDefinition("node {\n"
+                + "    cache(maxCacheSize: 100) {}\n"
+                + "}", true));
+
+        // WHEN
+        WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+        j.waitForCompletion(b);
+
+        // THEN
+        j.assertBuildStatus(Result.FAILURE, b);
+    }
+
+    @Test
+    public void testLegacyMaxCacheSizeParameterIsMissing() throws Exception {
+        // GIVEN
+        WorkflowJob p = j.createProject(WorkflowJob.class);
+        p.setDefinition(new CpsFlowDefinition("node {\n"
+                + "    dir ('sub') {}\n"
+                + "    cache(caches: [[$class: 'ArbitraryFileCache', path: 'sub', compressionMethod: 'NONE']]) {}"
+                + "}", true));
+
+        // WHEN
+        WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+        j.waitForCompletion(b);
+
+        // THEN
+        j.assertBuildStatus(Result.FAILURE, b);
+    }
+
+    @Test
+    public void testPathParameterIsMissing() throws Exception {
+        // GIVEN
+        WorkflowJob p = j.createProject(WorkflowJob.class);
+        p.setDefinition(new CpsFlowDefinition("node {\n"
+                + "    cache(key: 'a') {}\n"
+                + "}", true));
+
+        // WHEN
+        WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+        j.waitForCompletion(b);
+
+        // THEN
+        j.assertBuildStatus(Result.FAILURE, b);
+    }
+
+    @Test
+    public void testKeyParameterIsMissing() throws Exception {
+        // GIVEN
+        WorkflowJob p = j.createProject(WorkflowJob.class);
+        p.setDefinition(new CpsFlowDefinition("node {\n"
+                + "    dir ('sub') {}\n"
+                + "    cache(path: 'sub') {}\n"
+                + "}", true));
+
+        // WHEN
+        WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+        j.waitForCompletion(b);
+
+        // THEN
+        j.assertBuildStatus(Result.FAILURE, b);
+    }
+
+}


### PR DESCRIPTION
As discussed [here](https://github.com/j3t/jenkins-pipeline-cache-plugin/issues/10), we would like to have the functionality
provided by the `jenkins-pipeline-cache-plugin` in the `jobcacher-plugin` but we also want to be backward-compatible.

In order todo that, the `CacheStep` must be extended so that either the `maxCacheSize` and `caches` properties must be present or the `path` and `key` properties.

For sake of simplicity, the new cache step approach (Github Action Style) is only available for the `NonAWSS3ItemStorage` and the periodic eviction of LRU cache items is also not available yet but I guess it's a good starting point for further discussions.