### PR TITLE
make use of docker build agents

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,4 +2,7 @@
  See the documentation for more options:
  https://github.com/jenkins-infra/pipeline-library/
 */
-buildPlugin(useContainerAgent: true)
+buildPlugin(configurations: [
+  [ platform: "docker", jdk: "8", jenkins: null ],
+  [ platform: "docker-windows", jdk: "8", jenkins: null ]
+])


### PR DESCRIPTION
By default the plugin is built and tested on linux and windows but the default nodes are not supporting docker. According to the documentation, we have to change the configuration in order to have docker support.
