### PR TITLE
Add symbol for arbitraryFileCache

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The cache(s) will be restored before calling the closure and updated after execu
 
 ```groovy
 cache(maxCacheSize: 250, defaultBranch: 'develop', caches: [
-        [$class: 'ArbitraryFileCache', path: 'node_modules', cacheValidityDecidingFile: 'package-lock.json', compressionMethod: 'TARGZ']
+        arbitraryFileCache(path: 'node_modules', cacheValidityDecidingFile: 'package-lock.json', compressionMethod: 'TARGZ')
 ]) {
     // ...
 }

--- a/src/main/java/jenkins/plugins/jobcacher/ArbitraryFileCache.java
+++ b/src/main/java/jenkins/plugins/jobcacher/ArbitraryFileCache.java
@@ -33,6 +33,7 @@ import hudson.model.Job;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.util.ListBoxModel;
+import org.jenkinsci.Symbol;
 import jenkins.plugins.itemstorage.GlobalItemStorage;
 import jenkins.plugins.itemstorage.ObjectPath;
 import jenkins.plugins.jobcacher.arbitrary.*;
@@ -318,6 +319,7 @@ public class ArbitraryFileCache extends Cache {
     }
 
     @Extension
+    @Symbol("arbitraryFileCache")
     public static final class DescriptorImpl extends CacheDescriptor {
 
         @NonNull

--- a/src/test/java/jenkins/plugins/jobcacher/ArbitraryFileCachePipelineTest.java
+++ b/src/test/java/jenkins/plugins/jobcacher/ArbitraryFileCachePipelineTest.java
@@ -36,7 +36,7 @@ public class ArbitraryFileCachePipelineTest {
     @Test
     @WithTimeout(600)
     public void testArbitraryFileCacheWithinPipelineWithCacheValidityDecidingFile() throws Exception {
-        String cacheDefinition = "[$class: 'ArbitraryFileCache', path: 'test-path', cacheValidityDecidingFile: 'cacheValidityDecidingFile.txt']";
+        String cacheDefinition = "arbitraryFileCache(path: 'test-path', cacheValidityDecidingFile: 'cacheValidityDecidingFile.txt')";
         WorkflowJob project = createTestProject(cacheDefinition);
 
         WorkflowRun run1 = jenkins.assertBuildStatus(Result.SUCCESS, project.scheduleBuild2(0));
@@ -67,7 +67,7 @@ public class ArbitraryFileCachePipelineTest {
     @Test
     @WithTimeout(600)
     public void testNonExistingCacheValidityDecidingFile() throws Exception {
-        String cacheDefinition = "[$class: 'ArbitraryFileCache', path: 'test-path', cacheValidityDecidingFile: 'cacheValidityDecidingFile-unknown.txt']";
+        String cacheDefinition = "arbitraryFileCache(path: 'test-path', cacheValidityDecidingFile: 'cacheValidityDecidingFile-unknown.txt')";
         WorkflowJob project = createTestProject(cacheDefinition);
 
         WorkflowRun run1 = jenkins.assertBuildStatus(Result.SUCCESS, project.scheduleBuild2(0));
@@ -88,19 +88,19 @@ public class ArbitraryFileCachePipelineTest {
     @Test
     @WithTimeout(600)
     public void testUncompressedArbitraryFileCacheWithinPipeline() throws Exception {
-        testArbitraryFileCacheWithinPipeline("[$class: 'ArbitraryFileCache', path: 'test-path']");
+        testArbitraryFileCacheWithinPipeline("arbitraryFileCache(path: 'test-path')");
     }
 
     @Test
     @WithTimeout(600)
     public void testZipCompressedArbitraryFileCacheWithinPipeline() throws Exception {
-        testArbitraryFileCacheWithinPipeline("[$class: 'ArbitraryFileCache', path: 'test-path', compressionMethod: 'ZIP']");
+        testArbitraryFileCacheWithinPipeline("arbitraryFileCache(path: 'test-path', compressionMethod: 'ZIP')");
     }
 
     @Test
     @WithTimeout(600)
     public void testTarGzCompressedArbitraryFileCacheWithinPipeline() throws Exception {
-        testArbitraryFileCacheWithinPipeline("[$class: 'ArbitraryFileCache', path: 'test-path', compressionMethod: 'TARGZ']");
+        testArbitraryFileCacheWithinPipeline("arbitraryFileCache(path: 'test-path', compressionMethod: 'TARGZ')");
     }
 
     private void testArbitraryFileCacheWithinPipeline(String cacheDefinition) throws Exception {

--- a/src/test/java/jenkins/plugins/jobcacher/ArbitraryFileCacheStepMinioTest.java
+++ b/src/test/java/jenkins/plugins/jobcacher/ArbitraryFileCacheStepMinioTest.java
@@ -79,7 +79,7 @@ public class ArbitraryFileCacheStepMinioTest {
         // GIVEN
         WorkflowJob job = j.createProject(WorkflowJob.class);
         job.setDefinition(new CpsFlowDefinition("node {\n" +
-                "  cache(maxCacheSize: 250, caches: [[$class: 'ArbitraryFileCache', path: 'sub', compressionMethod: 'TARGZ']]){\n" +
+                "  cache(maxCacheSize: 250, caches: [arbitraryFileCache(path: 'sub', compressionMethod: 'TARGZ')]){\n" +
                 "    sh 'mkdir sub'\n" +
                 "    sh 'echo sub-content > sub/file'\n" +
                 "  }\n" +
@@ -97,7 +97,7 @@ public class ArbitraryFileCacheStepMinioTest {
         // GIVEN
         job.setDefinition(new CpsFlowDefinition("node {\n" +
                 "  sh 'rm -rf *'\n" +
-                "  cache(maxCacheSize: 250, caches: [[$class: 'ArbitraryFileCache', path: 'sub', compressionMethod: 'TARGZ']]){\n" +
+                "  cache(maxCacheSize: 250, caches: [arbitraryFileCache(path: 'sub', compressionMethod: 'TARGZ')]){\n" +
                 "    sh 'cat sub/file'\n" +
                 "  }\n" +
                 "}", true));


### PR DESCRIPTION
Make more user friendly pipeline by using symbol for arbitraryFileCache

```
cache(maxCacheSize: 250, defaultBranch: 'develop', caches: [arbitraryFileCache(path: 'node_modules', cacheValidityDecidingFile: 'package-lock.json', compressionMethod: 'TARGZ')]) {
    
}
```

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did

