### PR TITLE
Use minimal SDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,6 @@
 
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
 
-        <aws-java-sdk.version>1.12.586-413.v6a_6c3a_420126</aws-java-sdk.version>
         <testcontainers.version>1.19.3</testcontainers.version>
         <zstd-jni.version>1.5.5-10</zstd-jni.version>
     </properties>
@@ -59,9 +58,8 @@
             <artifactId>variant</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>aws-java-sdk</artifactId>
-            <version>${aws-java-sdk.version}</version>
+            <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
+            <artifactId>aws-java-sdk-minimal</artifactId>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/src/main/java/jenkins/plugins/itemstorage/s3/NonAWSS3ItemStorage.java
+++ b/src/main/java/jenkins/plugins/itemstorage/s3/NonAWSS3ItemStorage.java
@@ -145,7 +145,7 @@ public class NonAWSS3ItemStorage extends ItemStorage<S3ObjectPath> {
         return new S3Profile(lookupCredentials(), endpoint, region, signerVersion, pathStyleAccess, parallelDownloads);
     }
 
-    @OptionalExtension(requirePlugins = {"aws-java-sdk", "aws-credentials", "jackson2-api"})
+    @OptionalExtension(requirePlugins = {"aws-java-sdk-minimal", "aws-credentials", "jackson2-api"})
     public static final class DescriptorImpl extends ItemStorageDescriptor<S3ObjectPath> {
 
         @NonNull
@@ -175,7 +175,7 @@ public class NonAWSS3ItemStorage extends ItemStorage<S3ObjectPath> {
         }
     }
 
-    @OptionalExtension(requirePlugins = {"aws-java-sdk", "aws-credentials", "jackson2-api"})
+    @OptionalExtension(requirePlugins = {"aws-java-sdk-minimal", "aws-credentials", "jackson2-api"})
     public static final class S3ItemListener extends ItemListener {
 
         @Override

--- a/src/main/java/jenkins/plugins/itemstorage/s3/S3ItemStorage.java
+++ b/src/main/java/jenkins/plugins/itemstorage/s3/S3ItemStorage.java
@@ -107,7 +107,7 @@ public class S3ItemStorage extends ItemStorage<S3ObjectPath> {
         return new S3Profile(lookupCredentials(), null, region, null, false, true);
     }
 
-    @OptionalExtension(requirePlugins = {"aws-java-sdk", "aws-credentials", "jackson2-api"})
+    @OptionalExtension(requirePlugins = {"aws-java-sdk-minimal", "aws-credentials", "jackson2-api"})
     public static final class DescriptorImpl extends ItemStorageDescriptor<S3ObjectPath> {
 
         @NonNull
@@ -136,7 +136,7 @@ public class S3ItemStorage extends ItemStorage<S3ObjectPath> {
         }
     }
 
-    @OptionalExtension(requirePlugins = {"aws-java-sdk", "aws-credentials", "jackson2-api"})
+    @OptionalExtension(requirePlugins = {"aws-java-sdk-minimal", "aws-credentials", "jackson2-api"})
     public static final class S3ItemListener extends ItemListener {
 
         @Override


### PR DESCRIPTION
Currently migrating to external storage (artifact, etc..) and want to migrate job caches to S3 endpoint

Similar to S3 publisher : https://plugins.jenkins.io/s3/dependencies/, no need to bring all AWS dependencies (https://plugins.jenkins.io/aws-java-sdk-minimal/).

I'm not sure if there is a better migration path expect asking consumer to install the minimal SDK.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
