### PR TITLE
Add support base prefix

### DIFF
--- a/src/main/java/jenkins/plugins/itemstorage/s3/NonAWSS3ItemStorage.java
+++ b/src/main/java/jenkins/plugins/itemstorage/s3/NonAWSS3ItemStorage.java
@@ -60,6 +60,7 @@ public class NonAWSS3ItemStorage extends ItemStorage<S3ObjectPath> {
 
     private final String credentialsId;
     private final String bucketName;
+    private final String prefix;
     private final String endpoint;
     private final String region;
     private final String signerVersion;
@@ -69,6 +70,7 @@ public class NonAWSS3ItemStorage extends ItemStorage<S3ObjectPath> {
     @DataBoundConstructor
     public NonAWSS3ItemStorage(String credentialsId,
                                String bucketName,
+                               String prefix,
                                String endpoint,
                                String region,
                                String signerVersion,
@@ -76,6 +78,7 @@ public class NonAWSS3ItemStorage extends ItemStorage<S3ObjectPath> {
                                boolean parallelDownloads) {
         this.credentialsId = fixEmptyAndTrim(credentialsId);
         this.bucketName = fixEmptyAndTrim(bucketName);
+        this.prefix = fixEmptyAndTrim(prefix);
         this.endpoint = fixEmptyAndTrim(endpoint);
         this.region = fixEmptyAndTrim(region);
         this.signerVersion = fixEmptyAndTrim(signerVersion);
@@ -86,6 +89,11 @@ public class NonAWSS3ItemStorage extends ItemStorage<S3ObjectPath> {
     @SuppressWarnings("unused")
     public String getBucketName() {
         return bucketName;
+    }
+
+    @SuppressWarnings("unused")
+    public String getPrefix() {
+        return prefix;
     }
 
     @SuppressWarnings("unused")
@@ -142,7 +150,7 @@ public class NonAWSS3ItemStorage extends ItemStorage<S3ObjectPath> {
     }
 
     private S3Profile createS3Profile() {
-        return new S3Profile(lookupCredentials(), endpoint, region, signerVersion, pathStyleAccess, parallelDownloads);
+        return new S3Profile(lookupCredentials(), endpoint, region, prefix, signerVersion, pathStyleAccess, parallelDownloads);
     }
 
     @OptionalExtension(requirePlugins = {"aws-java-sdk-minimal", "aws-credentials", "jackson2-api"})

--- a/src/main/java/jenkins/plugins/itemstorage/s3/S3ItemStorage.java
+++ b/src/main/java/jenkins/plugins/itemstorage/s3/S3ItemStorage.java
@@ -56,18 +56,25 @@ public class S3ItemStorage extends ItemStorage<S3ObjectPath> {
 
     private final String credentialsId;
     private final String bucketName;
+    private final String prefix;
     private final String region;
 
     @DataBoundConstructor
-    public S3ItemStorage(String credentialsId, String bucketName, String region) {
+    public S3ItemStorage(String credentialsId, String bucketName, String prefix, String region) {
         this.credentialsId = credentialsId;
         this.bucketName = bucketName;
+        this.prefix = prefix;
         this.region = region;
     }
 
     @SuppressWarnings("unused")
     public String getBucketName() {
         return bucketName;
+    }
+
+    @SuppressWarnings("unused")
+    public String getPrefix() {
+        return prefix;
     }
 
     @SuppressWarnings("unused")
@@ -104,7 +111,7 @@ public class S3ItemStorage extends ItemStorage<S3ObjectPath> {
     }
 
     private S3Profile createS3Profile() {
-        return new S3Profile(lookupCredentials(), null, region, null, false, true);
+        return new S3Profile(lookupCredentials(), null, region, prefix, null, false, true);
     }
 
     @OptionalExtension(requirePlugins = {"aws-java-sdk-minimal", "aws-credentials", "jackson2-api"})

--- a/src/main/resources/jenkins/plugins/itemstorage/s3/NonAWSS3ItemStorage/config.jelly
+++ b/src/main/resources/jenkins/plugins/itemstorage/s3/NonAWSS3ItemStorage/config.jelly
@@ -31,6 +31,10 @@
         <f:textbox/>
     </f:entry>
 
+    <f:entry title="${%Base Prefix}" field="prefix">
+        <f:textbox/>
+    </f:entry>
+
     <f:entry title="${%S3 Endpoint}" field="endpoint">
         <f:textbox/>
     </f:entry>

--- a/src/main/resources/jenkins/plugins/itemstorage/s3/NonAWSS3ItemStorage/help-prefix.html
+++ b/src/main/resources/jenkins/plugins/itemstorage/s3/NonAWSS3ItemStorage/help-prefix.html
@@ -1,0 +1,1 @@
+<div>This is the string that will be used as prefix for every path, it must end with an "/". Useful to store caches on a subfolder bucket.</div>

--- a/src/main/resources/jenkins/plugins/itemstorage/s3/S3ItemStorage/config.jelly
+++ b/src/main/resources/jenkins/plugins/itemstorage/s3/S3ItemStorage/config.jelly
@@ -30,7 +30,9 @@
     <f:entry title="${%S3 Bucket Name}" field="bucketName">
         <f:textbox/>
     </f:entry>
-
+    <f:entry title="${%Base Prefix}" field="prefix">
+        <f:textbox/>
+    </f:entry>
     <f:entry title="${%Region}" field="region">
         <f:select/>
     </f:entry>

--- a/src/main/resources/jenkins/plugins/itemstorage/s3/S3ItemStorage/help-prefix.html
+++ b/src/main/resources/jenkins/plugins/itemstorage/s3/S3ItemStorage/help-prefix.html
@@ -1,0 +1,1 @@
+<div>This is the string that will be used as prefix for every path, it must end with an "/". Useful to store caches on a subfolder bucket.</div>

--- a/src/test/java/jenkins/plugins/jobcacher/ArbitraryFileCacheStepMinioTest.java
+++ b/src/test/java/jenkins/plugins/jobcacher/ArbitraryFileCacheStepMinioTest.java
@@ -65,6 +65,7 @@ public class ArbitraryFileCacheStepMinioTest {
         NonAWSS3ItemStorage storage = new NonAWSS3ItemStorage(
                 "minio-test-credentials-id",
                 bucket,
+                "instances1/",
                 minio.getExternalAddress(),
                 "us-west-1",
                 null,


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/jobcacher-plugin/issues/256

The easiest was to add on the S3Profile what encapsulate all call to S3/Minio. It will ensure all path are added with prefix if needed

In some some cases you want to store multiple instances caches on the same bucket but you have different ACL for folders.

Similar to `artifact-manager-s3-plugin` to add a prefix on all path

```
      {
         "Effect": "Allow",
         "Action": "s3:ListBucket",
         "Resource": "arn:aws:s3:::caches",
         "Condition": {
               "StringLike": {
                  "s3:prefix": "instance1/*"
               }
         }
      }
```

### Testing done

- Automated tests
- Interactive tests with Minio instance (tester with empty or with prefix). See evidences bollow
- Also tested job renaming with subdir

UI

![tests_prefix](https://github.com/jenkinsci/jobcacher-plugin/assets/825750/cfd65f1d-9b22-4b7d-b110-4bdd13320085)

No prefix

![test_cache_no_prefix](https://github.com/jenkinsci/jobcacher-plugin/assets/825750/7381a895-8ab3-4603-baec-a3b2b977695b)

With prefix 

![test_cache_with_prefix](https://github.com/jenkinsci/jobcacher-plugin/assets/825750/df214c47-c15c-42ec-9afd-169a8778639e)


```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure that the pull request title represents the desired changelog entry
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```


