### PR TITLE
Implement dynamic linking with Commons Compress library plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>commons-compress-api</artifactId>
+            <version>1.26.1-1</version>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
         </dependency>
@@ -78,10 +83,6 @@
             <optional>true</optional>
         </dependency>
 
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-compress</artifactId>
-        </dependency>
         <dependency>
             <groupId>com.github.luben</groupId>
             <artifactId>zstd-jni</artifactId>
@@ -198,11 +199,32 @@
                     <groupId>org.jenkins-ci.tools</groupId>
                     <artifactId>maven-hpi-plugin</artifactId>
                     <configuration>
-                        <pluginFirstClassLoader>true</pluginFirstClassLoader>
+                        <maskClasses>org.apache.commons.compress.</maskClasses>
                     </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <!-- TODO remove when Commons Compress is removed from core -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>display-info</id>
+                        <configuration>
+                            <rules>
+                                <requireUpperBoundDeps>
+                                    <excludes combine.children="append">
+                                        <exclude>org.apache.commons:commons-compress</exclude>
+                                    </excludes>
+                                </requireUpperBoundDeps>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
     <licenses>


### PR DESCRIPTION
See [this thread](https://groups.google.com/g/jenkinsci-dev/c/dRY7NYuvLkM/m/8v65Z2MsAgAJ). We are planning on removing Commons Compress from core. Even though this plugin currently provides its own copy bundled in the JPI using `pluginFirstClassLoader`, that copy will now be competing with the copy from the Commons Compress library plugin. Our experience is that different plugins providing the same JARs is generally problematic, so switch to using the newly-created library plugin instead via a plugin-to-plugin dependency.

### Testing done

`mvn clean verify -Dtest=InjectedTest`