### PR TITLE
Shrink size of JPI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,10 +79,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-compress</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.github.luben</groupId>
             <artifactId>zstd-jni</artifactId>
             <version>${zstd-jni.version}</version>
@@ -190,20 +186,6 @@
             <scope>test</scope>
           </dependency>
     </dependencies>
-
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.jenkins-ci.tools</groupId>
-                    <artifactId>maven-hpi-plugin</artifactId>
-                    <configuration>
-                        <pluginFirstClassLoader>true</pluginFirstClassLoader>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-    </build>
 
     <licenses>
         <license>


### PR DESCRIPTION
No need to bundle this library or use exotic class loading schemes, as the version supplied by the core baseline is up-to-date.