### PR TITLE
Upgrade Jenkins core to 2.440 and follow pom archetype for bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,9 +18,8 @@
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
 
-        <jenkins.version>2.426.3</jenkins.version>
-        <jenkins-tools-bom.artifactId>bom-2.426.x</jenkins-tools-bom.artifactId>
-        <jenkins-tools-bom.version>3208.vb_21177d4b_cd9</jenkins-tools-bom.version>
+        <jenkins.baseline>2.440</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
 
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
 
@@ -41,8 +40,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>${jenkins-tools-bom.artifactId}</artifactId>
-                <version>${jenkins-tools-bom.version}</version>
+                <artifactId>bom-${jenkins.baseline}.x</artifactId>
+                <version>3221.ve8f7b_fdd149d</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -174,13 +173,11 @@
         <dependency>
             <groupId>io.jenkins</groupId>
             <artifactId>configuration-as-code</artifactId>
-            <version>${configuration-as-code.version}</version>
             <scope>test</scope>
           </dependency>
           <dependency>
             <groupId>io.jenkins.configuration-as-code</groupId>
             <artifactId>test-harness</artifactId>
-            <version>${configuration-as-code.version}</version>
             <scope>test</scope>
           </dependency>
           <dependency>


### PR DESCRIPTION
See https://github.com/jenkinsci/archetypes/pull/737/files

Also bom 2.462.x stopped to receive update. So upgrading to next basline

### Testing done

Automated tests only

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
