### PR TITLE
Return mutable collection from getProjectActions

### DIFF
--- a/src/main/java/jenkins/plugins/jobcacher/CacheBuildLastAction.java
+++ b/src/main/java/jenkins/plugins/jobcacher/CacheBuildLastAction.java
@@ -44,7 +44,7 @@ public class CacheBuildLastAction extends InvisibleAction implements SimpleBuild
 
     @Override
     public Collection<? extends Action> getProjectActions() {
-        return Collections.singletonList(cacheProjectAction);
+        return new ArrayList<>(Collections.singletonList(cacheProjectAction));
     }
 
     void addCaches(List<Cache> caches) {


### PR DESCRIPTION

<!-- Please describe your pull request here. -->
### Description
Jenkins may attempt to modify the collection returned by getProjectActions().
Returning an immutable list can therefore lead to UnsupportedOperationException at runtime.

This change ensures a mutable list is returned, aligning with Jenkins plugin API expectations and fixing the issue described in #323.

### Testing done

This is a trivial and isolated change that replaces an immutable collection with a mutable one while preserving the same content and behavior.

The change mirrors fixes already applied in other Jenkins plugins for the same issue pattern.
CI coverage is considered sufficient for this change.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
