### PR TITLE
Fix UnsupportedOperationException when using multiple cache blocks

### DIFF
--- a/src/main/java/jenkins/plugins/jobcacher/CacheProjectAction.java
+++ b/src/main/java/jenkins/plugins/jobcacher/CacheProjectAction.java
@@ -26,6 +26,7 @@ package jenkins.plugins.jobcacher;
 
 import hudson.model.Action;
 import hudson.model.Job;
+import java.util.ArrayList;
 import java.util.List;
 import org.kohsuke.stapler.Stapler;
 
@@ -37,7 +38,7 @@ public class CacheProjectAction implements Action {
     private final List<Cache> caches;
 
     public CacheProjectAction(List<Cache> caches) {
-        this.caches = caches;
+        this.caches = new ArrayList<>(caches);
     }
 
     @Override

--- a/src/test/java/jenkins/plugins/jobcacher/CacheBuildLastActionTest.java
+++ b/src/test/java/jenkins/plugins/jobcacher/CacheBuildLastActionTest.java
@@ -1,0 +1,69 @@
+package jenkins.plugins.jobcacher;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link CacheBuildLastAction} to ensure it handles unmodifiable lists correctly.
+ */
+class CacheBuildLastActionTest {
+
+    @Test
+    void testAddCachesWithUnmodifiableInitialList() {
+        // Create an ArbitraryFileCache for testing
+        ArbitraryFileCache cache1 = new ArbitraryFileCache("path1", null, null);
+        ArbitraryFileCache cache2 = new ArbitraryFileCache("path2", null, null);
+
+        // Create CacheBuildLastAction with an unmodifiable singleton list
+        // This simulates what happens when a pipeline uses a single cache definition
+        List<Cache> unmodifiableList = Collections.singletonList(cache1);
+        CacheBuildLastAction action = new CacheBuildLastAction(unmodifiableList);
+
+        // This should NOT throw UnsupportedOperationException
+        // Before the fix, this would fail because addAll() was called on the unmodifiable list
+        action.addCaches(Collections.singletonList(cache2));
+
+        // Verify both caches are present
+        CacheProjectAction projectAction = (CacheProjectAction) action.getProjectActions().iterator().next();
+        assertThat(projectAction.getCaches(), hasSize(2));
+        assertThat(projectAction.getCaches(), containsInAnyOrder(cache1, cache2));
+    }
+
+    @Test
+    void testAddCachesWithEmptyUnmodifiableList() {
+        ArbitraryFileCache cache = new ArbitraryFileCache("path", null, null);
+
+        // Create with empty unmodifiable list
+        List<Cache> emptyList = Collections.emptyList();
+        CacheBuildLastAction action = new CacheBuildLastAction(emptyList);
+
+        // Should not throw
+        action.addCaches(Collections.singletonList(cache));
+
+        CacheProjectAction projectAction = (CacheProjectAction) action.getProjectActions().iterator().next();
+        assertThat(projectAction.getCaches(), hasSize(1));
+        assertThat(projectAction.getCaches(), contains(cache));
+    }
+
+    @Test
+    void testAddCachesMultipleTimes() {
+        ArbitraryFileCache cache1 = new ArbitraryFileCache("path1", null, null);
+        ArbitraryFileCache cache2 = new ArbitraryFileCache("path2", null, null);
+        ArbitraryFileCache cache3 = new ArbitraryFileCache("path3", null, null);
+
+        // Start with unmodifiable list
+        CacheBuildLastAction action = new CacheBuildLastAction(List.of(cache1));
+
+        // Add caches multiple times (simulates multiple cache blocks in a pipeline)
+        action.addCaches(List.of(cache2));
+        action.addCaches(List.of(cache3));
+
+        CacheProjectAction projectAction = (CacheProjectAction) action.getProjectActions().iterator().next();
+        assertThat(projectAction.getCaches(), hasSize(3));
+        assertThat(projectAction.getCaches(), containsInAnyOrder(cache1, cache2, cache3));
+    }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
